### PR TITLE
Do not depend on Mix for env

### DIFF
--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -15,6 +15,8 @@ defmodule Faktory do
 
   alias Faktory.{Logger, Protocol, Utils, Configuration}
 
+  defdelegate env, to: Utils
+
   @doc false
   def start_workers? do
     !!get_env(:start_workers)
@@ -35,6 +37,7 @@ defmodule Faktory do
   @spec push(atom | binary, Keyword.t, [term]) :: jid
   def push(module, args, options \\ []) do
     import Faktory.Utils, only: [new_jid: 0]
+    import Faktory.TestHelp, only: [if_test: 1]
 
     module = Module.safe_concat([module])
     options = Keyword.merge(module.faktory_options, options)
@@ -54,7 +57,7 @@ defmodule Faktory do
 
     # To facilitate testing, we keep a map if jid -> pid and send messages to
     # the pid at various points in the job's lifecycle.
-    if Mix.env == :test do
+    if_test do
       TestJidPidMap.register(job["jid"])
     end
 

--- a/lib/faktory/test_help.ex
+++ b/lib/faktory/test_help.ex
@@ -2,12 +2,7 @@ defmodule Faktory.TestHelp do
 
   defmacro if_test(do: block) do
     if Faktory.Utils.env == :test do
-      quote do
-        unquote(block)
-      end
-    else
-      quote do
-      end
+      quote do: unquote(block)
     end
   end
 

--- a/lib/faktory/test_help.ex
+++ b/lib/faktory/test_help.ex
@@ -1,0 +1,14 @@
+defmodule Faktory.TestHelp do
+
+  defmacro if_test(do: block) do
+    if Faktory.Utils.env == :test do
+      quote do
+        unquote(block)
+      end
+    else
+      quote do
+      end
+    end
+  end
+
+end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -68,4 +68,13 @@ defmodule Faktory.Utils do
     :os.system_time(:milli_seconds)
   end
 
+  def env do
+    cond do
+      function_exported?(Mix, :env, 1) -> Mix.env
+      Application.get_env(@app_name, :env) != nil -> Application.get_env(@app_name, :env)
+      Map.has_key?(System.get_env, "MIX_ENV") -> System.get_env("MIX_ENV")
+      true -> :dev
+    end
+  end
+
 end

--- a/lib/faktory/worker.ex
+++ b/lib/faktory/worker.ex
@@ -4,6 +4,7 @@ defmodule Faktory.Worker do
 
   alias Faktory.{Logger, Protocol, Executor}
   import Faktory.Utils, only: [now_in_ms: 0]
+  import Faktory.TestHelp, only: [if_test: 1]
 
   def start_link(config) do
     GenServer.start_link(__MODULE__, config)
@@ -110,7 +111,7 @@ defmodule Faktory.Worker do
     {:ok, _} = with_conn(state, &Protocol.ack(&1, jid))
     Logger.debug("ack'ed #{jid}")
 
-    if Mix.env == :test do
+    if_test do
       send TestJidPidMap.get(jid), {:report_ack, %{job: job, time: time}}
     end
   end
@@ -127,7 +128,7 @@ defmodule Faktory.Worker do
     {:ok, _} = with_conn(state, &Protocol.fail(&1, jid, errtype, message, trace))
     Logger.debug("fail'ed #{jid}")
 
-    if Mix.env == :test do
+    if_test do
       send TestJidPidMap.get(jid), {:report_fail, %{job: job, time: time, error: error}}
     end
   end


### PR DESCRIPTION
Some build tools (exrm, Distillery) don't include Mix. See here for reason: https://github.com/bitwalker/exrm/issues/67#issuecomment-60040251

This code adds `Faktory.Utils.env` (which `Faktory.env` delegates to). It tries a number of ways to get the env:
1. `Mix.env` if `Mix` is available.
1. `Application.get_env(@app_name, :env)`
1. `MIX_ENV` environment var.
1. Defaults to `:dev`

Because the function tries a number of ways and doesn't memoize the results, there is `Faktory.TestHelp.if_test` that compiles to nothing if `env == :test`, otherwise the block given. This is so in non-test environments, the block is completely removed at compile time and we don't waste any cpu cycles.