### PR TITLE
Add authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ You should be able to go to [http://localhost:7420](http://localhost:7420) and s
 
 ## What's missing?
 
-* Authentication
 * TLS
 * Responding to the terminate signal (from the Faktory server)
 * Tests

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run this readme's example, you need to run a Faktory server.
 
 Easiest way is with Docker:
 ```
-docker run --rm -it -p 7419:7419 -p 7420:7420 contribsys/faktory:0.5.0 -b 0.0.0.0:7419 -no-tls
+docker run --rm -it -p 7419:7419 -p 7420:7420 contribsys/faktory:latest -b 0.0.0.0:7419
 ```
 
 You should be able to go to [http://localhost:7420](http://localhost:7420) and see the web ui.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ version: "3"
 services:
 
   dev:
-    image: contribsys/faktory:0.5.0
-    command: -b :7419 -no-tls -l debug
+    image: contribsys/faktory:latest
+    command: -b :7419 -l debug
     ports:
       - "7419:7419"
       - "7420:7420"
 
   test:
-    image: contribsys/faktory:0.5.0
-    command: -b :7419 -no-tls -l debug
+    image: contribsys/faktory:latest
+    command: -b :7419 -l debug
     ports:
       - "7421:7419"
       - "7422:7420"

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -32,6 +32,7 @@ defmodule Faktory.Configuration do
 
   * `host` - Faktory server host. Default `"localhost"`
   * `port` - Faktory server port. Default `7419`
+  * `password` - Faktory server password. Default `nil`
   * `config_fn` - Callback function for runtime config. Default `nil`
 
   ### Client Options
@@ -125,6 +126,7 @@ defmodule Faktory.Configuration do
     config = config
       |> put_from_env(:host, :host)
       |> put_from_env(:port, :port)
+      |> put_from_env(:password, :password)
       |> put_from_env(:fn, :config_fn)
       |> Keyword.put(:name, name)
 

--- a/lib/faktory/configuration/client.ex
+++ b/lib/faktory/configuration/client.ex
@@ -3,7 +3,7 @@ defmodule Faktory.Configuration.Client do
 
   defstruct [
     host: "localhost", port: 7419, pool: 10, middleware: [], fn: nil,
-    name: "default", wid: nil
+    name: "default", wid: nil, password: nil
   ]
 
 end

--- a/lib/faktory/configuration/worker.ex
+++ b/lib/faktory/configuration/worker.ex
@@ -3,7 +3,7 @@ defmodule Faktory.Configuration.Worker do
 
   defstruct [
     host: "localhost", port: 7419, pool: nil, middleware: [], fn: nil,
-    name: "default", concurrency: 20, wid: nil, queues: ["default"]
+    name: "default", concurrency: 20, wid: nil, queues: ["default"], password: nil
   ]
 
 end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -77,4 +77,13 @@ defmodule Faktory.Utils do
     end
   end
 
+  def hash_password(iterations, password, salt) do
+    1..iterations
+    |> Enum.reduce(password <> salt, fn(_i, acc) ->
+      :crypto.hash(:sha256, acc)
+    end)
+    |> Base.encode16()
+    |> String.downcase()
+  end
+
 end

--- a/test/lib/faktory/utils_tests.exs
+++ b/test/lib/faktory/utils_tests.exs
@@ -1,0 +1,16 @@
+defmodule Faktory.UtilsTests do
+  use ExUnit.Case, async: true
+
+  describe "hash_password/3" do
+    test "it correctly salts and hashes the password" do
+      iterations = 1545
+      password = "foobar"
+      salt = "55104dc76695721d"
+
+      expected = "6d877f8e5544b1f2598768f817413ab8a357afffa924dedae99eb91472d4ec30"
+      actual = Faktory.Utils.hash_password(iterations, password, salt)
+
+      assert expected == actual
+    end
+  end
+end


### PR DESCRIPTION
This implements the password hashing scheme documented [here](https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#initial-handshake) and updates the worker to speak version 2 of the Faktory server protocol.

Any thoughts on how unit-ish tests should be structured for something like this? I think it would be nice to test `Connection` in isolation somehow. Building a mock server for it seems heavy to me, but maybe that would be useful for other tests too.

cc @cjbottaro 