### PR TITLE
Add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ You should be able to go to [http://localhost:7420](http://localhost:7420) and s
 ## What's missing?
 
 * Authentication
-* TLS
 * Responding to the terminate signal (from the Faktory server)
 * Tests
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :faktory_worker_ex,
   port: 7421,
   client: [pool: 5],
+  use_tls: false,
   workers: [
     default: [
       concurrency: 2

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -125,6 +125,7 @@ defmodule Faktory.Configuration do
     config = config
       |> put_from_env(:host, :host)
       |> put_from_env(:port, :port)
+      |> put_from_env(:use_tls, :use_tls)
       |> put_from_env(:fn, :config_fn)
       |> Keyword.put(:name, name)
 

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -129,6 +129,14 @@ defmodule Faktory.Configuration do
       |> put_from_env(:fn, :config_fn)
       |> Keyword.put(:name, name)
 
+    # TODO: Support the rest of the CLI options
+    cli_options = Application.get_env(:faktory_worker_ex, :cli_options)
+    config = if use_tls = cli_options[:use_tls] do
+      config ++ [use_tls: use_tls]
+    else
+      config
+    end
+
     # Convert to struct.
     config = struct!(type, config)
 

--- a/lib/faktory/configuration/client.ex
+++ b/lib/faktory/configuration/client.ex
@@ -3,7 +3,7 @@ defmodule Faktory.Configuration.Client do
 
   defstruct [
     host: "localhost", port: 7419, pool: 10, middleware: [], fn: nil,
-    name: "default", wid: nil
+    name: "default", wid: nil, use_tls: false
   ]
 
 end

--- a/lib/faktory/configuration/worker.ex
+++ b/lib/faktory/configuration/worker.ex
@@ -3,7 +3,7 @@ defmodule Faktory.Configuration.Worker do
 
   defstruct [
     host: "localhost", port: 7419, pool: nil, middleware: [], fn: nil,
-    name: "default", concurrency: 20, wid: nil, queues: ["default"]
+    name: "default", concurrency: 20, wid: nil, queues: ["default"], use_tls: false
   ]
 
 end

--- a/lib/faktory/connection.ex
+++ b/lib/faktory/connection.ex
@@ -31,11 +31,13 @@ defmodule Faktory.Connection do
     host = String.to_charlist(host)
     transport = if use_tls, do: :ssl, else: :gen_tcp
 
+    certs = :certifi.cacerts()
+
     base_opts = [:binary, active: false]
     tcp_opts = if use_tls do
       # Disable TLS verification in dev/test so that self-signed certs will work
       verify_opts = if Mix.env in [:dev, :test], do: [verify: :verify_none], else: [verify: :verify_peer]
-      base_opts ++ verify_opts ++ [versions: [:'tlsv1.2']]
+      base_opts ++ verify_opts ++ [versions: [:'tlsv1.2'], depth: 99, cacerts: certs]
     else
       base_opts
     end

--- a/lib/faktory/tasks/faktory.ex
+++ b/lib/faktory/tasks/faktory.ex
@@ -21,8 +21,8 @@ defmodule Mix.Tasks.Faktory do
   @doc false
   def run(args) do
     OptionParser.parse(args,
-      strict: [concurrency: :integer, queues: :string, pool: :integer],
-      aliases: [c: :concurrency, q: :queues, p: :pool]
+      strict: [concurrency: :integer, queues: :string, pool: :integer, use_tls: :boolean],
+      aliases: [c: :concurrency, q: :queues, p: :pool, t: :use_tls, tls: :use_tls]
     ) |> case do
       {options, [], []} -> start(options)
       _ ->
@@ -51,6 +51,7 @@ defmodule Mix.Tasks.Faktory do
     -c, --concurrency  Number of worker processes
     -q, --queues       Comma seperated list of queues
     -p, --pool         Connection pool size. Default: <concurrency>
+    -t, --tls          Enable TLS when connecting to Faktory server. Default: disable TLS
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule Faktory.Mixfile do
       {:poison, "~> 3.1"},
       {:poolboy, "~> 1.5"},
       {:ex_doc, "~> 0.18.1", only: :dev},
+      {:certifi, "~> 2.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [], [], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},


### PR DESCRIPTION
This adds support for connecting to a TLS-protected Faktory server. It validates server certificates in production mode but not dev/test. The CLI option handling for `mix faktory` is a bit broken/messy and is something I'll work on in a subsequent PR.

I developed a simple Docker image that makes TLS testing easy, but IMO it would be better suited for the main Faktory repo than this one — each client library could use it.

In the meantime:
```$ docker run --rm -it -p 7419-7420:7419-7420/tcp acjensen/faktory-tls:latest```

There will be small conflicts with #6, but they should be easy to resolve.

cc @cjbottaro 