### PR TITLE
Fix nil application name

### DIFF
--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -9,14 +9,9 @@ defmodule Faktory do
   # A connection to the Faktory server.
   @type conn :: pid
 
-  # Retain this at compile time since Mix.* will not be available in release builds
-  @app_name Mix.Project.config[:app]
-
-  @doc false
-  def app_name, do: @app_name
-
   alias Faktory.{Logger, Protocol, Utils, Configuration}
 
+  defdelegate app_name, to: Utils
   defdelegate env, to: Utils
 
   @doc false
@@ -112,12 +107,12 @@ defmodule Faktory do
 
   @doc false
   def get_env(key) do
-     Application.get_env(@app_name, key)
+     Application.get_env(app_name(), key)
   end
 
   @doc false
   def put_env(key, value) do
-    Application.put_env(@app_name, key, value)
+    Application.put_env(app_name(), key, value)
   end
 
   @doc """

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -9,7 +9,11 @@ defmodule Faktory do
   # A connection to the Faktory server.
   @type conn :: pid
 
-  @app_name Application.get_application(__MODULE__)
+  # Retain this at compile time since Mix.* will not be available in release builds
+  @app_name Mix.Project.config[:app]
+
+  @doc false
+  def app_name, do: @app_name
 
   alias Faktory.{Logger, Protocol, Utils, Configuration}
 

--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -207,7 +207,7 @@ defmodule Faktory.Configuration do
   end
 
   defp get_env(key) do
-    Application.get_env(:faktory_worker_ex, key)
+    Application.get_env(Faktory.app_name(), key)
   end
 
   defp put_from_env(enum, dst, src) do

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -73,7 +73,7 @@ defmodule Faktory.Utils do
     # Not really dry since Faktory does this same call to populate a module var,
     # but we can't call functions on Faktory otherwise we get a circular
     # dependency and deadlock errors.
-    app_name = Application.get_application(Faktory)
+    app_name = Faktory.app_name()
 
     cond do
       function_exported?(Mix, :env, 1) -> Mix.env

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -1,6 +1,11 @@
 defmodule Faktory.Utils do
   @moduledoc false
 
+  # Retain this at compile time since Mix.* will not be available in release builds
+  @app_name Mix.Project.config[:app]
+
+  def app_name, do: @app_name
+
   def put_unless_nil(enum, _key, nil), do: enum
   def put_unless_nil(enum, key, value) when is_list(enum) do
     Keyword.put(enum, key, value)
@@ -69,15 +74,9 @@ defmodule Faktory.Utils do
   end
 
   def env do
-
-    # Not really dry since Faktory does this same call to populate a module var,
-    # but we can't call functions on Faktory otherwise we get a circular
-    # dependency and deadlock errors.
-    app_name = Faktory.app_name()
-
     cond do
       function_exported?(Mix, :env, 1) -> Mix.env
-      Application.get_env(app_name, :env) -> Application.get_env(app_name, :env)
+      Application.get_env(@app_name, :env) -> Application.get_env(@app_name, :env)
       Map.has_key?(System.get_env, "MIX_ENV") -> System.get_env("MIX_ENV")
       true -> :dev
     end


### PR DESCRIPTION
The application isn't loaded at compile time, so `Application.get_application(__MODULE__)` will return `nil`. And since it's stored in a module attribute, the `nil` is retained and not reevaluated at run time. It still mostly works because `nil` is a valid configuration key, but it breaks the `mix faktory` task flags and is very confusing.

Instead, we can use `Mix.Project.config[:app]` which is available at compile time. I don't know whether there will be any wrinkles with umbrella projects. I think the most common use case will be to use this project as a normal dependency, though.