### PR TITLE
Fix TLS flag

### DIFF
--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -133,8 +133,8 @@ defmodule Faktory.Configuration do
 
     # TODO: Support the rest of the CLI options
     cli_options = Application.get_env(:faktory_worker_ex, :cli_options)
-    config = if use_tls = cli_options[:use_tls] do
-      config ++ [use_tls: use_tls]
+    config = if tls = cli_options[:tls] do
+      config ++ [use_tls: tls]
     else
       config
     end

--- a/lib/faktory/tasks/faktory.ex
+++ b/lib/faktory/tasks/faktory.ex
@@ -21,8 +21,8 @@ defmodule Mix.Tasks.Faktory do
   @doc false
   def run(args) do
     OptionParser.parse(args,
-      strict: [concurrency: :integer, queues: :string, pool: :integer, use_tls: :boolean],
-      aliases: [c: :concurrency, q: :queues, p: :pool, t: :use_tls, tls: :use_tls]
+      strict: [concurrency: :integer, queues: :string, pool: :integer, tls: :boolean],
+      aliases: [c: :concurrency, q: :queues, p: :pool, t: :tls]
     ) |> case do
       {options, [], []} -> start(options)
       _ ->


### PR DESCRIPTION
Multi-character aliases are deprecated (and apparently also semi-broken) in modern Elixir.

cc @cjbottaro 