### PR TITLE
"mix faktory -q" should be space separated, not comma

### DIFF
--- a/lib/faktory/tasks/faktory.ex
+++ b/lib/faktory/tasks/faktory.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Faktory do
     mix faktory [options]
 
     -c, --concurrency  Number of worker processes
-    -q, --queues       Comma seperated list of queues
+    -q, --queues       Space seperated list of queues
     -p, --pool         Connection pool size. Default: <concurrency>
     -t, --tls          Enable TLS when connecting to Faktory server. Default: disable TLS
     """


### PR DESCRIPTION
`mix faktory -h` suggests that the queue names are supposed to be comma separated, this however doesn't work. Reading [the code](https://github.com/cjbottaro/faktory_worker_ex/blob/master/lib/faktory/protocol.ex#L22-L35) I think it should be space separated rather.