### PR TITLE
Fully implement RESP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -----------
 * Use GenStage instead of BlockingQueue. (PR [#36](https://github.com/cjbottaro/faktory_worker_ex/pull/36))
 * Find the right job module when jobtype doesn't match module name. (PR [#35](https://github.com/cjbottaro/faktory_worker_ex/pull/35))
-* Implement Redis Serialization Protocol (RESP)
+* Implement Redis Serialization Protocol (RESP). (PR [#40](https://github.com/cjbottaro/faktory_worker_ex/pull/40))
 * Use Jason instead of Poison.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -----------
 * Use GenStage instead of BlockingQueue. (PR [#36](https://github.com/cjbottaro/faktory_worker_ex/pull/36))
 * Find the right job module when jobtype doesn't match module name. (PR [#35](https://github.com/cjbottaro/faktory_worker_ex/pull/35))
+* Implement Redis Serialization Protocol (RESP)
 * Use Jason instead of Poison.
 
 

--- a/lib/faktory/connection.ex
+++ b/lib/faktory/connection.ex
@@ -144,7 +144,7 @@ defmodule Faktory.Connection do
     state.socket_impl.send(state.socket, chomp(data) <> "\r\n")
   end
 
-  defp socket_recv(state, size, options \\ [])
+  defp socket_recv(state, size, options)
 
   defp socket_recv(state, :line, options) do
     case state.socket_impl.recv(state.socket, :line, options) do

--- a/lib/faktory/protocol.ex
+++ b/lib/faktory/protocol.ex
@@ -15,7 +15,7 @@ defmodule Faktory.Protocol do
 
   @type jid :: binary
 
-  alias Faktory.{Connection, Resp}
+  alias Faktory.{Utils, Connection, Resp}
 
   def handshake(conn, hello) do
     with \

--- a/lib/faktory/resp.ex
+++ b/lib/faktory/resp.ex
@@ -1,0 +1,51 @@
+defmodule Faktory.Resp do
+  @moduledoc false
+
+  def recv(conn) do
+    with {:ok, line} <- Faktory.Connection.recv(conn, :line) do
+      parse_resp(line, conn)
+    end
+  end
+
+  defp parse_resp(line, conn) when is_binary(line) do
+    case line do
+      <<"+", line::binary>> -> parse_resp(:simple_string, line)
+      <<"-", line::binary>> -> parse_resp(:error, line)
+      <<":", line::binary>> -> parse_resp(:integer, line)
+      <<"$", line::binary>> -> parse_resp(:bulk_string, line, conn)
+      <<"*", line::binary>> -> raise(ArgumentError, message: "RESP arrays not implemented: #{line}")
+    end
+  end
+
+  defp parse_resp(:simple_string, line) do
+    {:ok, line}
+  end
+
+  defp parse_resp(:error, line) do
+    {:ok, {:error, line}}
+  end
+
+  defp parse_resp(:integer, line) do
+    {:ok, String.to_integer(line)}
+  end
+
+  # (empty string) "$0\r\n\r\n" -> {:ok, ""}
+  defp parse_resp(:bulk_string, "0", conn) do
+    Faktory.Connection.recv(conn, :line)
+  end
+
+  # (null) "$-1\r\n" -> {:ok, nil}
+  defp parse_resp(:bulk_string, "-1", _conn) do
+    {:ok, nil}
+  end
+
+  # (bulk string) "$6\r\nfoobar\r\n" -> {:ok, "foobar"}
+  defp parse_resp(:bulk_string, line, conn) do
+    size = String.to_integer(line) + 2 # Don't forget the \r\n
+    case Faktory.Connection.recv(conn, size) do
+      {:ok, bulk} -> {:ok, String.replace_suffix(bulk, "\r\n", "")}
+      error -> error
+    end
+  end
+
+end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -49,6 +49,10 @@ defmodule Faktory.Utils do
     :os.system_time(:milli_seconds)
   end
 
+  def elapsed(start_time) do
+    (System.monotonic_time(:millisecond) - start_time) / 1000
+  end
+
   def env do
     cond do
       function_exported?(Mix, :env, 1) -> Mix.env
@@ -58,7 +62,7 @@ defmodule Faktory.Utils do
     end
   end
 
-  def hash_password(iterations, password, salt) do
+  def hash_password(password, salt, iterations) do
     1..iterations
     |> Enum.reduce(password <> salt, fn(_i, acc) ->
       :crypto.hash(:sha256, acc)

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Faktory.Mixfile do
 
   defp aliases do
     [
-      # compile: ["compile --warnings-as-errors"]
+      compile: ["compile --warnings-as-errors"]
     ]
   end
 end

--- a/test/lib/faktory/utils_test.exs
+++ b/test/lib/faktory/utils_test.exs
@@ -8,7 +8,7 @@ defmodule Faktory.UtilsTest do
       salt = "55104dc76695721d"
 
       expected = "6d877f8e5544b1f2598768f817413ab8a357afffa924dedae99eb91472d4ec30"
-      actual = Faktory.Utils.hash_password(iterations, password, salt)
+      actual = Faktory.Utils.hash_password(password, salt, iterations)
 
       assert expected == actual
     end


### PR DESCRIPTION
Heh, I had no idea this was a thing. Makes things a lot easier. 👍 

Faktory speaks [RESP](https://redis.io/topics/protocol). Knowing that now, `faktory_server_ex` now speaks RESP property, and is thus more resilient to not-exactly-expected messages from the Faktory server.