### PR TITLE
Individual queues aka non-priority queues

### DIFF
--- a/lib/faktory/heartbeat.ex
+++ b/lib/faktory/heartbeat.ex
@@ -60,11 +60,8 @@ defmodule Faktory.Heartbeat do
 
   def handle_info(:quiet, %{quiet: true} = state), do: {:noreply, state}
   def handle_info(:quiet, state) do
-    config = state.config
-    Enum.each 1..config.fetcher_count, fn index ->
-      name = Faktory.Stage.Fetcher.name(config, index)
-      GenStage.call(name, :quiet)
-    end
+    Faktory.Stage.Fetcher.names(state.config)
+    |> Enum.each(&GenStage.call(&1, :quiet))
     {:noreply, %{state | quiet: true}}
   end
 

--- a/lib/faktory/stage/queue.ex
+++ b/lib/faktory/stage/queue.ex
@@ -1,0 +1,34 @@
+defmodule Faktory.Stage.Queue do
+  @moduledoc false
+
+  def child_spec(config) do
+    %{
+      id: {config.module, __MODULE__},
+      start: {__MODULE__, :start_link, [config]},
+    }
+  end
+
+  def name(config) do
+    Faktory.Registry.name({config.module, __MODULE__})
+  end
+
+  def start_link(config) do
+    GenStage.start_link(__MODULE__, config, name: name(config))
+  end
+
+  def init(config) do
+    Faktory.Logger.debug "Queue stage #{inspect self()} starting up"
+    {:producer_consumer, config, subscribe_to: subscribe_to(config)}
+  end
+
+  def handle_events([job], _from, state) do
+    {:noreply, [job], state}
+  end
+
+  defp subscribe_to(config) do
+    Enum.map Faktory.Stage.Fetcher.names(config), fn fetcher ->
+      {fetcher, max_demand: 1, min_demand: 0}
+    end
+  end
+
+end

--- a/lib/faktory/supervisor.ex
+++ b/lib/faktory/supervisor.ex
@@ -11,11 +11,16 @@ defmodule Faktory.Supervisor do
   def init(config) do
     heartbeat = {Faktory.Heartbeat, config}
 
-    fetchers = Enum.map 1..config.fetcher_count, fn index ->
-      {Faktory.Stage.Fetcher, {config, index}}
-    end
+    fetchers = config
+    |> Faktory.Stage.Fetcher.queues
+    |> Enum.map(fn queue ->
+      config = %{config | queues: [queue]}
+      {Faktory.Stage.Fetcher, {config, queue}}
+    end)
 
-    runners = Enum.map 1..config.concurrency, fn index ->
+    queue = {Faktory.Stage.Queue, config}
+
+    workers = Enum.map 1..config.concurrency, fn index ->
       {Faktory.Stage.Worker, {config, index}}
     end
 
@@ -23,7 +28,7 @@ defmodule Faktory.Supervisor do
       {Faktory.Stage.Reporter, {config, index}}
     end
 
-    children = [heartbeat | fetchers ++ runners ++ reporters]
+    children = [heartbeat | fetchers ++ [queue] ++ workers ++ reporters]
     Supervisor.init(children, strategy: :one_for_one)
   end
 

--- a/lib/faktory/worker.ex
+++ b/lib/faktory/worker.ex
@@ -56,6 +56,20 @@ defmodule Faktory.Worker do
   running jobs to finish after receiving instruction to shutdown. For example from
   receiving a SIGTERM, or from the Faktory server issuing a `terminate` command
   (clicking the stop button in the web UI).
+
+  ## Priority queues
+
+  By default priority queues are enabled. This means if you configure a worker to monitor
+  queues `["a", "b", "c"]`, then all messages in queue `"a"` must be fetched before going
+  on to `"b"`, and so forth.
+
+  You can disable this behavior by setting `priority_queues: false` on the worker. In this example,
+  that means three fetcher processes (and thus three connections to the Faktory server) will
+  be started. One monitoring queue `"a"`, one monitoring queue `"b"`, and one monitoring
+  queue `"c"`. Jobs will be dispatched immediately, given available capacity to process them.
+
+  Disabling priority queues also works around this limitation of the Faktory server:
+  [#232](https://github.com/contribsys/faktory/issues/232)
   """
 
   @defaults [
@@ -66,9 +80,9 @@ defmodule Faktory.Worker do
     queues: ["default"],
     password: nil,
     use_tls: false,
-    fetcher_count: 1,
     reporter_count: 1,
-    shutdown_grace_period: 25_000
+    shutdown_grace_period: 25_000,
+    priority_queues: true
   ]
 
   @doc """
@@ -84,9 +98,9 @@ defmodule Faktory.Worker do
     queues: ["default"],
     password: nil,
     use_tls: false,
-    fetcher_count: 1,
     reporter_count: 1,
-    shutdown_grace_period: 25_000
+    shutdown_grace_period: 25_000,
+    priority_queues: true
   ]
   ```
   """
@@ -142,9 +156,9 @@ defmodule Faktory.Worker do
     queues: ["default"],
     password: nil,
     use_tls: false,
-    fetcher_count: 1,
     reporter_count: 1,
-    shutdown_grace_period: 25_000
+    shutdown_grace_period: 25_000,
+    priority_queues: true
   ]
   ```
 


### PR DESCRIPTION
There is now a `priority_queues: false` option to start a separate fetcher for each queue.

If you're only monitoring a single queue, then this option does nothing.

There is module documentation on `Faktory.Worker`, but the gist of it is, with this option turned on for a worker, then there will be a single fetcher that runs `FETCH queue1 queue2 queue3`.

With this option set to false, 3 fetcher processes will be launched, each one running its own fetch command on its own connection to the Faktory server:
`FETCH queue1`
`FETCH queue2`
`FETCH queue3`

Any jobs enqueued to any of those queues will be dispatched _immediately_ given sufficient capacity to handle the work.

The config option is:
```
use Mix.Config
config :my_app, MyWorker, priority_queues: false
```
Or any of the various ways to configure a worker.

Using `priority_queues: false` works around this limitation of the Faktory server: https://github.com/contribsys/faktory/issues/232