### PR TITLE
Specify job options on `use Faktory.Job`

### DIFF
--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -41,12 +41,6 @@ defmodule Faktory do
     client = options[:client] || get_env(:default_client)
     jobtype = options[:jobtype]
 
-    # if !Configuration.exists?(client) do
-    #   name = Faktory.Utils.module_name(client)
-    #   raise Faktory.Error.ClientNotConfigured,
-    #     message: "#{name} not configured"
-    # end
-
     job = options
       |> Keyword.merge(jid: new_jid(), jobtype: jobtype, args: args)
       |> Utils.stringify_keys

--- a/lib/faktory/job.ex
+++ b/lib/faktory/job.ex
@@ -26,15 +26,19 @@ defmodule Faktory.Job do
   ### Configuring
 
   You can configure various aspects of the job by passing a keyword list to
-  `faktory_options/1`.
+  `use Faktory.Job` or `faktory_options/1`. They are both functionally the
+  same and it's mostly an issue of style.
 
   ```elixir
   defmodule MyFunkyJob do
+    use Faktory.Job, queue: "default", retry: 25, backtrace: 0
+  end
+
+  # These are equivalent.
+
+  defmodule MyFunkyJob do
     use Faktory.Job
-
     faktory_options queue: "default", retry: 25, backtrace: 0
-
-    # ...
   end
   ```
 
@@ -50,18 +54,33 @@ defmodule Faktory.Job do
   ```
   """
 
-  defmacro __using__(_options) do
+  @defaults [
+    queue: "default",
+    retry: 25,
+    backtrace: 0,
+    middleware: []
+  ]
+
+  @doc """
+  Returns the default job configuration.
+
+  ```elixir
+  iex(1)> Faktory.Job.defaults
+  #{inspect @defaults}
+  ```
+  """
+  def defaults do
+    @defaults
+  end
+
+  defmacro __using__(options) do
     quote do
       @behaviour Faktory.Job
       import Faktory.Job, only: [faktory_options: 1]
-      @faktory_options [
-        queue: "default",
-        jobtype: Faktory.Utils.module_name(__MODULE__),
-        retry: 25,
-        backtrace: 0,
-        middleware: []
-      ]
+      @faktory_options Keyword.merge(Faktory.Job.defaults, jobtype: inspect(__MODULE__))
       @before_compile Faktory.Job
+
+      faktory_options(unquote(options))
 
       def perform_async(args, options \\ []) do
         Faktory.push(__MODULE__, args, options)

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -6,14 +6,6 @@ defmodule Faktory.Utils do
 
   def app_name, do: @app_name
 
-  def module_name(string) when is_binary(string) do
-    String.replace_prefix(string, "Elixir.", "")
-  end
-
-  def module_name(module) when is_atom(module) do
-    module |> Module.split |> Enum.join(".")
-  end
-
   # This will convert an enum into a map with string keys.
   def stringify_keys(map) do
     Enum.reduce map, %{}, fn {k, v}, acc ->


### PR DESCRIPTION
Been wanting to add this for a while.

It let's you specify job options on the call to `use`...
```elixir
defmodule MyJob do
  use Faktory.Job, queue: "foo", jobtype: "My::Job"
end
```
instead of...
```elixir
defmodule MyJob do
  use Faktory.Job
  faktory_options queue: "foo", jobtype: "My::Job"
end
```

The latter still works though and isn't going away. Maybe soft deprecated?