### PR TITLE
Elixir 1.9 release compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,33 @@ docker run --rm -p 7419:7419 -p 7420:7420 contribsys/faktory:latest -b :7419 -w 
 
 You should be able to go to [http://localhost:7420](http://localhost:7420) and see the web ui.
 
+## Using with releases
+
+There is basic support for releases that were introduced in Elixir 1.9.
+
+There are two ways to start up the workers when using releases:
+
+1. Setting an environment variable:
+```
+START_FAKTORY_WORKERS=1
+```
+2. Using `config/release.exs`:
+```
+config :faktory_worker_ex, :start_workers, true
+```
+
+There is no support for command line arguments when using releases.
+
 ## Features
 
 * Middleware
 * Connection pooling (for clients)
 * Support for multiple Faktory servers
 * Faktory server authentication and TLS support
+* Elixir 1.9 release support
 * Comprehensive documentation
 * Comprehensive supervision tree
 * Decent integration tests
-
-## Missing features
-
-* Release support
 
 ## Issues / Questions
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :faktory_worker_ex, :test, true
+
 config :faktory_worker_ex, Test.Client,
   port: 7421,
   pool: 5

--- a/lib/faktory/logger.ex
+++ b/lib/faktory/logger.ex
@@ -2,30 +2,30 @@ defmodule Faktory.Logger do
   @moduledoc false
   require Logger
 
-  defmacro __using__(_) do
-    quote do
-      import Faktory.Logger
-    end
+  faktory_level = Faktory.get_env(:log_level, :debug)
+  logger_level = Application.get_env(:logger, :level)
+
+  if Logger.compare_levels(faktory_level, logger_level) == :gt do
+    @level faktory_level
+  else
+    @level logger_level
   end
 
-  def debug(msg), do: log(:debug,"[faktory] #{msg}")
-  def info(msg), do: log(:info, "[faktory] #{msg}")
-  def warn(msg), do: log(:warn, "[faktory] #{msg}")
+  def level do
+    @level
+  end
+
+  # #TODO use macros to compile out stuff.
+
+  def debug(msg), do: log(:debug, "[faktory] #{msg}")
+  def info(msg),  do: log(:info,  "[faktory] #{msg}")
+  def warn(msg),  do: log(:warn,  "[faktory] #{msg}")
   def error(msg), do: log(:error, "[faktory] #{msg}")
 
-  defp log(level, msg) do
-    if level_high_enough?(level) do
-      Logger.log(level, msg)
+  def log(level, message) do
+    if Logger.compare_levels(@level, level) != :gt do
+      Logger.log(level, message)
     end
-  end
-
-  @level_map [debug: 0, info: 1, warn: 2, error: 3]
-
-  defp level_high_enough?(level) do
-    level = @level_map[level]
-    config_level = @level_map[Faktory.log_level]
-
-    level >= config_level
   end
 
 end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -1,11 +1,6 @@
 defmodule Faktory.Utils do
   @moduledoc false
 
-  # Retain this at compile time since Mix.* will not be available in release builds
-  @app_name Mix.Project.config[:app]
-
-  def app_name, do: @app_name
-
   # This will convert an enum into a map with string keys.
   def stringify_keys(map) do
     Enum.reduce map, %{}, fn {k, v}, acc ->
@@ -45,15 +40,6 @@ defmodule Faktory.Utils do
     (System.monotonic_time(:millisecond) - start_time) / 1000
   end
 
-  def env do
-    cond do
-      function_exported?(Mix, :env, 1) -> Mix.env
-      Application.get_env(@app_name, :env) -> Application.get_env(@app_name, :env)
-      Map.has_key?(System.get_env, "MIX_ENV") -> System.get_env("MIX_ENV")
-      true -> :dev
-    end
-  end
-
   def hash_password(password, salt, iterations) do
     1..iterations
     |> Enum.reduce(password <> salt, fn(_i, acc) ->
@@ -63,8 +49,23 @@ defmodule Faktory.Utils do
     |> String.downcase()
   end
 
+  @doc false
+  def get_all_env do
+    Application.get_all_env(:faktory_worker_ex)
+  end
+
+  @doc false
+  def get_env(key, default \\ nil) do
+     Application.get_env(:faktory_worker_ex, key, default)
+  end
+
+  @doc false
+  def put_env(key, value) do
+    Application.put_env(:faktory_worker_ex, key, value)
+  end
+
   defmacro if_test(do: block) do
-    if Faktory.Utils.env == :test do
+    if get_env(:test) do
       quote do: unquote(block)
     end
   end


### PR DESCRIPTION
Basic support for Elixir 1.9 releases.

From the README.md...

## Using with releases

There is basic support for releases that were introduced in Elixir 1.9.

There are two ways to start up the workers when using releases:

1. Setting an environment variable:
```
START_FAKTORY_WORKERS=1
```
2. Using `config/release.exs`:
```
config :faktory_worker_ex, :start_workers, true
```

There is no support for command line arguments when using releases.