### PR TITLE
Move protocol functions to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 Detailed info in the linked pull requests.
 
+* Move protocol functions to `Faktory.Client` (PR [#61](https://github.com/cjbottaro/faktory_worker_ex/pull/61))
 * Erlang modules don't expose `__info__/1`. (PR [#58](https://github.com/cjbottaro/faktory_worker_ex/pull/58))
 * Make `Faktory.push/2` a low level API. (PR [#57](https://github.com/cjbottaro/faktory_worker_ex/pull/57))
 * Make `Faktory.push/2` return errors. (PR [#57](https://github.com/cjbottaro/faktory_worker_ex/pull/57))

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To see command line options that can override in-app configuration.
 
 ## Configuration
 
-Compile-time config is done with `Mix.Config`.
+Compile-time config is done with `Config`.
 
 Run-time config is done with environment variables and/or an `init/1` callback.
 
@@ -95,6 +95,39 @@ config :faktory_worker_ex, :start_workers, true
 ```
 
 There is no support for command line arguments when using releases.
+
+## Using with multiple Faktory servers
+
+```elixir
+import Config
+
+config :my_app, FooClient,
+  host: "foo.faktory.myapp.com"
+
+config :my_app, BarClient,
+  host: "bar.faktory.myapp.com"
+
+defmodule FooClient do
+  use Faktory.Client, otp_app: :my_app
+end
+
+defmodule BarClient do
+  use Faktory.Client, otp_app: :my_app
+end
+
+defmodule FooJob do
+  use Faktory.Job, client: FooClient
+  def perform(), do: nil
+end
+
+defmodule BarJob do
+  use Faktory.Job, client: BarClient
+  def perform(), do: nil
+end
+
+FooJob.perform_async([]) # Enqueues job to Faktory server at foo.faktory.myapp.com
+BarJob.perform_async([]) # Enqueues job to Faktory server at bar.faktory.myapp.com
+```
 
 ## Features
 

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -1,7 +1,5 @@
 defmodule Faktory do
-  @moduledoc """
-  Some utility functions and such. See README for general usage.
-  """
+  @moduledoc false
 
   # Represents a unique job id.
   @type jid :: binary
@@ -23,118 +21,22 @@ defmodule Faktory do
   # A connection to the Faktory server.
   @type conn :: pid
 
-  alias Faktory.{Logger, Protocol, Utils}
+  def get_env(key, default \\ nil) do
+    Application.get_env(:faktory_worker_ex, key, default)
+  end
 
-  @doc false
-  defdelegate get_all_env(), to: Utils
-
-  @doc false
-  defdelegate get_env(key, default \\ nil), to: Utils
-
-  @doc false
-  defdelegate put_env(key, value), to: Utils
+  def put_env(key, value) do
+    Application.put_env(:faktory_worker_ex, key, value)
+  end
 
   @doc false
   def start_workers? do
-    !!get_env(:start_workers) or !!System.get_env("START_FAKTORY_WORKERS")
+    !!get_env(:start_workers)
+    or !!System.get_env("START_FAKTORY_WORKERS")
   end
 
-  @doc """
-  Lower level enqueing function.
-
-  Manually enqueue a Faktory job. A job is defined here:
-  https://github.com/contribsys/faktory/wiki/The-Job-Payload
-
-  This function will set the JID for you, you do not have to set it yourself.
-
-  `options` is a keyword list specifying...
-
-  `:client` Client module to use for a Faktory server connection. If omitted, the
-  default client is used.
-
-  `:middleware` Send the job through this middleware.
-
-  Ex:
-  ```elixir
-    push(%{"jobtype" => "MyFunWork", "args" => [1, 2, "three"], "queue" => "somewhere"})
-    push(job, client: ClientFoo, middleware: TheJobMangler)
-  ```
-  """
-  @spec push(job, options :: Keyword.t) :: {:ok, job} | {:error, reason :: binary}
-  def push(job, options \\ []) do
-    import Faktory.Utils, only: [new_jid: 0, if_test: 1, blank?: 1]
-    alias Faktory.Middleware
-
-    if blank?(job["jobtype"]) do
-      {:error, "missing required field jobtype"}
-    else
-      client = options[:client] || get_env(:default_client)
-
-      middleware = if Keyword.has_key?(options, :middleware) do
-        options[:middleware] || []
-      else
-        client.config[:middleware]
-      end
-
-      job = if blank?(job["jid"]) do
-        Map.put(job, "jid", new_jid())
-      else
-        job
-      end
-
-      # To facilitate testing, we keep a map of jid -> pid and send messages to
-      # the pid at various points in the job's lifecycle.
-      if_test do: TestJidPidMap.register(job["jid"])
-
-      result = Middleware.traverse(job, middleware, fn job ->
-        with_conn(options, &Protocol.push(&1, job))
-      end)
-
-      case result do
-        {:ok, _} ->
-          %{ "jid" => jid, "args" => args, "jobtype" => jobtype} = job
-          Logger.info "Q 🕒 #{inspect self()} jid-#{jid} (#{jobtype}) #{inspect(args)}"
-          {:ok, job}
-
-        error -> error
-      end
-    end
-
-  end
-
-  @doc """
-  Get info from the Faktory server.
-
-  Returns the info as a map (parsed JSON).
-  Checks out a connection from the _client_ pool.
-  """
-  @spec info :: map
-  def info(options \\ []) do
-    with_conn(options, &Protocol.info(&1))
-  end
-
-  @doc """
-  Flush (clear) the Faktory db.
-
-  All job info will be lost.
-  Checks out a connection from the _client_ pool.
-  """
-  @spec flush :: :ok | {:error, binary}
-  def flush(options \\ []) do
-    with_conn(options, &Protocol.flush(&1))
-  end
-
-  @doc """
-  Need a raw connection to the Faktory server?
-
-  This checks one out, passes it to the given function, then checks it back
-  in. See the (undocument) `Faktory.Protocol` module for what you can do
-  with a connection.
-  """
-  @spec with_conn(Keyword.t, (conn -> term)) :: term
-  def with_conn(options, func) do
-    client = options[:client] || get_env(:default_client)
-    :poolboy.transaction(client, func)
+  def default_client() do
+    Application.get_env(:faktory_worker_ex, :default_client)
   end
 
 end

--- a/lib/faktory/error.ex
+++ b/lib/faktory/error.ex
@@ -1,7 +1,10 @@
 defmodule Faktory.Error do
   @moduledoc false
 
-  defmodule InvalidJobType, do: defexception [:message]
+  defmodule InvalidJobType do
+    @moduledoc false
+    defexception [:message]
+  end
 
   defstruct [:errtype, :message, trace: []]
 

--- a/lib/faktory/error/client_not_configured.ex
+++ b/lib/faktory/error/client_not_configured.ex
@@ -1,3 +1,4 @@
 defmodule Faktory.Error.ClientNotConfigured do
+  @moduledoc false
   defexception message: "Client not configured"
 end

--- a/lib/faktory/job.ex
+++ b/lib/faktory/job.ex
@@ -109,7 +109,8 @@ defmodule Faktory.Job do
     jobtype: "MyFunkyJob",
     retry: 25,
     middleware: [],
-    backtrace: 10
+    backtrace: 10,
+    client: nil
   ]
   ```
   """
@@ -128,7 +129,7 @@ defmodule Faktory.Job do
   MyJob.perform_async(job_args, queue: "not_default" jobtype: "Worker::MyJob")
   ```
   """
-  @callback perform_async(args :: [any], options :: Keyword.t | []) :: job
+  @callback perform_async(args :: [any], options :: Keyword.t | []) :: {:ok, job} | {:error, reason :: binary}
 
   @doc """
   Set default options for all jobs of this type.
@@ -154,7 +155,9 @@ defmodule Faktory.Job do
       "retry" => options[:retry],
       "backtrace" => options[:backtrace]
     }
-    Faktory.push(job, options)
+
+    client = options[:client] || Faktory.default_client() || raise("No default client configured")
+    client.push(job, options)
   end
 
 end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -53,23 +53,8 @@ defmodule Faktory.Utils do
     |> String.downcase()
   end
 
-  @doc false
-  def get_all_env do
-    Application.get_all_env(:faktory_worker_ex)
-  end
-
-  @doc false
-  def get_env(key, default \\ nil) do
-     Application.get_env(:faktory_worker_ex, key, default)
-  end
-
-  @doc false
-  def put_env(key, value) do
-    Application.put_env(:faktory_worker_ex, key, value)
-  end
-
   defmacro if_test(do: block) do
-    if get_env(:test) do
+    if Faktory.get_env(:test) do
       quote do: unquote(block)
     end
   end

--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -46,4 +46,8 @@ defmodule BasicTest do
     assert error.errtype == "UndefinedFunctionError"
   end
 
+  test ":client option on job" do
+    assert CustomClientJob.faktory_options[:client] == CustomClient
+  end
+
 end

--- a/test/support/custom_client_job.ex
+++ b/test/support/custom_client_job.ex
@@ -1,0 +1,3 @@
+defmodule CustomClientJob do
+  use Faktory.Job, client: CustomClient
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,7 +5,7 @@ Supervisor.start_link(
   strategy: :one_for_one
 )
 
-Faktory.flush
+Test.Client.flush()
 {:ok, _} = PidMap.start_link
 {:ok, _} = TestJidPidMap.start_link
 


### PR DESCRIPTION
Move functions like `push`, `info`, and `flush` to the client.

I decided to leave the idea of "default client" in so that jobs don't have to specify a client in the "one Faktory server" scenario.