### PR TITLE
--no-start option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 Detailed info in the linked pull requests.
 
+* --no-start command line option (PR [#62](https://github.com/cjbottaro/faktory_worker_ex/pull/62))
 * Move protocol functions to `Faktory.Client` (PR [#61](https://github.com/cjbottaro/faktory_worker_ex/pull/61))
 * Erlang modules don't expose `__info__/1`. (PR [#58](https://github.com/cjbottaro/faktory_worker_ex/pull/58))
 * Make `Faktory.push/2` a low level API. (PR [#57](https://github.com/cjbottaro/faktory_worker_ex/pull/57))

--- a/lib/faktory/tasks/faktory.ex
+++ b/lib/faktory/tasks/faktory.ex
@@ -19,29 +19,33 @@ defmodule Mix.Tasks.Faktory do
 
   @doc false
   def run(args) do
-    OptionParser.parse(args,
-      strict: [concurrency: :integer, queues: :string, pool: :integer, tls: :boolean],
+    {faktory_args, run_args} = Enum.split_while(args, & &1 != "--")
+
+    # Ditch the "--" from run_args if there are any run_args.
+    run_args = case run_args do
+      ["--" | run_args] -> run_args
+      run_args -> run_args
+    end
+
+    OptionParser.parse(faktory_args,
+      strict: [concurrency: :integer, queues: :string, pool: :integer, tls: :boolean, no_start: :boolean],
       aliases: [c: :concurrency, q: :queues, p: :pool, t: :tls]
     ) |> case do
-      {options, [], []} -> start(options)
+      {options, [], []} -> start(options, run_args)
       _ ->
         print_usage()
         exit(:normal)
     end
   end
 
-  defp start(options) do
+  defp start(options, run_args) do
     # Signify that we want to start the workers.
     Faktory.put_env(:start_workers, true)
 
     # Store our cli options.
     Faktory.put_env(:cli_options, options)
 
-    # Easy enough.
-    Mix.Task.run "app.start"
-
-    # Do the equivalent of --no-halt unless running in IEx.
-    unless IEx.started?, do: Process.sleep(:infinity)
+    Mix.Tasks.Run.run run_args ++ no_start_arg(options) ++ no_halt_arg()
   end
 
   defp print_usage do
@@ -51,7 +55,24 @@ defmodule Mix.Tasks.Faktory do
     -c, --concurrency  Number of worker processes
     -q, --queues       Space seperated list of queues
     -t, --tls          Enable TLS when connecting to Faktory server. Default: disable TLS
+    --no-start         Do not start applications after compilation (like mix run --no-start)
     """
+  end
+
+  defp no_start_arg(options) do
+    if options[:no_start] do
+      ["--no-start"]
+    else
+      []
+    end
+  end
+
+  defp no_halt_arg do
+    if iex_running?(), do: [], else: ["--no-halt"]
+  end
+
+  defp iex_running? do
+    Code.ensure_loaded?(IEx) and IEx.started?()
   end
 
 end


### PR DESCRIPTION
This gives an option `mix faktory --no-start` which is similar to `mix run --no-start`.

Use case is large umbrella apps where you don't want to start a bunch of unnecessary applications. For example, you could make a mix task that calls `Mix.Task.run("faktory", ["--no-start"])`, then manually starts up only the applications you want.