### PR TITLE
Granular control over starting workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 Detailed info in the linked pull requests.
 
+* Granular control over starting workers. (PR [#64](https://github.com/cjbottaro/faktory_worker_ex/pull/64)
 * Graceful shutdown. (PR [#43](https://github.com/cjbottaro/faktory_worker_ex/pull/43), [#56](https://github.com/cjbottaro/faktory_worker_ex/pull/56), [#63](https://github.com/cjbottaro/faktory_worker_ex/pull/63))
 * Internally respect "reserve_for" (PR [#63](https://github.com/cjbottaro/faktory_worker_ex/pull/63))
 * --no-start command line option (PR [#62](https://github.com/cjbottaro/faktory_worker_ex/pull/62))

--- a/lib/faktory/supervisor.ex
+++ b/lib/faktory/supervisor.ex
@@ -9,12 +9,24 @@ defmodule Faktory.Supervisor do
   end
 
   def init(config) do
-    [
-      {Faktory.Manager, config},
-      {Faktory.Stage.Fetcher, config},
-      {Faktory.Stage.Worker, config}
-    ]
+    if start?(config) do
+      [
+        {Faktory.Manager, config},
+        {Faktory.Stage.Fetcher, config},
+        {Faktory.Stage.Worker, config}
+      ]
+    else
+      []
+    end
     |> Supervisor.init(strategy: :one_for_one)
+  end
+
+  defp start?(config) do
+    if Map.has_key?(config, :start) do
+      config.start
+    else
+      Faktory.start_workers?
+    end
   end
 
 end

--- a/lib/faktory/worker.ex
+++ b/lib/faktory/worker.ex
@@ -154,20 +154,7 @@ defmodule Faktory.Worker do
     Faktory.Configuration.call(module, @defaults)
   end
 
-  @doc false
-  def child_spec(module, options) do
-    child_spec(module, options, Faktory.start_workers?)
-  end
-
-  @doc false
-  def child_spec(module, _options, false) do
-    %{
-      id: module,
-      start: {Task, :start_link, [fn -> Process.sleep(:infinity) end]}
-    }
-  end
-
-  def child_spec(module, _options, true) do
+  def child_spec(module, _options) do
     %{
       id: module,
       start: {Faktory.Supervisor, :start_link, [module]},


### PR DESCRIPTION
Adding the `:start` key to a worker's configuration will now override the global `mix faktory` task about which workers to start.

```elixir 
config :my_app, MyApp.MyWorker, start: false

# mix faktory will not start worker
```

```elixir
config :my_app, MyApp.MyWorker, start: true

# mix run will start worker
```

This makes it easier to control which workers you want to start up.