### PR TITLE
Client/connection refactor

### DIFF
--- a/dev/client.ex
+++ b/dev/client.ex
@@ -1,4 +1,4 @@
-defmodule Dev.Client do
-  @moduledoc false
-  use Faktory.Client, otp_app: :faktory_worker_ex
-end
+# defmodule Dev.Client do
+#   @moduledoc false
+#   use Faktory.Client, otp_app: :faktory_worker_ex
+# end

--- a/dev/client.ex
+++ b/dev/client.ex
@@ -1,4 +1,16 @@
-# defmodule Dev.Client do
-#   @moduledoc false
-#   use Faktory.Client, otp_app: :faktory_worker_ex
-# end
+defmodule Dev.Pool do
+  @moduledoc false
+
+  use ConnectionPool, size: 2
+
+  def start_spec(name) do
+    {
+      Faktory.Client,
+      :start_link,
+      [
+        [],
+        [name: name]
+      ]
+    }
+  end
+end

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -1,13 +1,268 @@
 defmodule ConnectionPool do
+  @moduledoc """
+  Pooling for GenServers.
+
+  Notable features
+  * Connections are dynamically supervised named GenServers.
+  * Connections are lazily started.
+  * Connections are automatically checked in if the owner process dies.
+  * Telemetry events.
+
+  ## Named GenServers
+
+  Each connection is a named GenServer that is dynamically supervised. This
+  allows the connection to be restarted and continue to be used without having
+  to get a new pid.
+
+  ```
+  {:ok, pool} = ConnectionPool.start_link(...)
+  {:ok, conn} = ConnectionPool.checkout(pool)
+  {:ok, result} = SomeConnection.do_something(conn)
+
+  GenServer.whereis(conn) |> Process.exit(:kill)
+
+  # Still works because dynamic supervisor restarted connection.
+  {:ok, result} = SomeConnection.do_something(conn)
+
+  :ok = ConnectionPool.checkout(pool, conn)
+  ```
+
+  ## Start Spec
+
+  You must provide a "start spec" that let's `ConnectionPool` know how to start
+  your connections, including how to name them. It is a function that takes a
+  name as an argument.
+
+  ```
+  {:ok, pool} = ConnectionPool.start_link(start: fn name ->
+    {SomeConnection, :start_link, [[host, "foo.com", name: name]]}
+  end)
+  ```
+
+  ## Configuration
+
+  There is a robust (but simple) configuration system that allows for both
+  compile time and run time configuration.
+
+  See `defaults/0` and `config/0` for more info.
+
+  ## Using as a Module
+
+  ```
+  defmodule MyPool do
+    use ConnectionPool,
+      start: fn -> ... end,
+      size: 5,
+      timeout: 2_000
+  end
+
+  MyPool.start_link()
+  {:ok, conn} = MyPool.checkout()
+  :ok = MyPool.checkin(conn)
+  ```
+
+  You can specify a `c:start_spec/1` callback in lieu of providing the `:start`
+  option.
+
+  You can specify configuration specific to your module. See `c:config/0` for
+  more info.
+
+  ## Telemetry Events
+
+  You can see these events in action by calling:
+  ```
+  :ok = ConnectionPool.Telemetry.init_logging()
+  ```
+
+  How long `checkin/2` took:
+  ```
+  [
+    [:connection_pool, :checkin],
+    %{usec: usec},
+    %{result: result}
+  ]
+  ```
+
+  How long `checkout/2` took:
+  ```
+  [
+    [:connection_pool, :checkout],
+    %{usec: usec},
+    %{result: result}
+  ]
+  ```
+
+  How long a connection was checked out for:
+  ```
+  [
+    [:connection_pool, :checkout, :duration],
+    %{usec: usec},
+    %{conn: conn}
+  ]
+  ```
+
+  When a connection is automatically checked in due to a process ending. The time
+  reported is how long it was checked out for:
+  ```
+  [
+    [:connection_pool, :checkout, :reaped],
+    %{usec: usec},
+    %{conn: conn, reason: reason}
+  ]
+  ```
+  """
+
   use GenServer
 
+  defmacro __using__(config \\ []) do
+    quote do
+      @config unquote(config)
+
+      def config do
+        Keyword.merge(ConnectionPool.config(), @config)
+      end
+
+      def start_spec(name), do: "not implemented"
+      defoverridable(start_spec: 1)
+
+      def child_spec(config) do
+        %{
+          id: {ConnectionPool, __MODULE__},
+          start: {__MODULE__, :start_link, [config]}
+        }
+      end
+
+      def start_link(config \\ []) do
+        Keyword.merge(config(), config)
+        |> Keyword.put_new(:start, &start_spec/1)
+        |> ConnectionPool.start_link(name: __MODULE__)
+      end
+
+      def debug do
+        ConnectionPool.debug(__MODULE__)
+      end
+
+      def checkout(opts \\ [], f \\ nil) do
+        ConnectionPool.checkout(__MODULE__, opts, f)
+      end
+
+      def checkin(conn) do
+        ConnectionPool.checkin(__MODULE__, conn)
+      end
+
+    end
+  end
+
+  @type pool :: GenServer.server()
+  @type conn :: GenServer.server()
+
   @defaults [
+    start: nil,
     size: 10,
     timeout: 5_000,
   ]
 
+  @doc """
+  Specific connection pool configuation.
+
+  The module's specific configuration will be merged with `config/0`.
+
+  ```
+  config :connection_pool, ConnectionPool, timeout: 1_000
+  config :my_app, MyPool, size: 2
+
+  iex(1)> ConnectionPool.config()
+  #{inspect Keyword.merge(@defaults, timeout: 1_000), pretty: true, width: 0}
+
+  iex(2)> MyPool.config()
+  #{inspect Keyword.merge(@defaults, timeout: 1_000, size: 2), pretty: true, width: 0}
+  ```
+  """
+  @callback config :: Keyword.t
+
+  @doc """
+  Returns a specification to start this module under a supervisor.
+
+  ```
+  defmodule MyPool do
+    use ConnectionPool
+  end
+
+  children = [MyPool]
+  Supervisor.start_link(children, strategy: :one_for_one)
+
+  children = [{MyPool, size: 5}]
+  Supervisor.start_link(children, strategy: :one_for_one)
+  ```
+  """
+  @callback child_spec(config :: Keyword.t) :: Supervisor.child_spec()
+
+  @doc """
+  See `checkout/2`.
+  """
+  @callback checkout(opts :: Keyword.t) :: {:ok, conn} | {:error, term}
+
+  @doc """
+  See `checkin/2`.
+  """
+  @callback checkin(conn) :: :ok | {:error, term}
+
+  @doc """
+  See `transaction/3`.
+  """
+  @callback transaction(opts :: Keyword.t, (conn -> term)) :: {:ok, term} | {:error, term}
+
+  @doc """
+  Alternative to the `:start` option.
+
+  You can use this instead of specifying the `:start` option.
+  ```
+  defmodule MyPool do
+    use ConnectionPool, size: 2
+
+    def start_spec(name) do
+      {SomeConnection, :start_link, [[name: name]]}
+    end
+  end
+  ```
+  """
+  @callback start_spec(name :: GenServer.name()) :: {atom, atom, [term]}
+
+  @doc """
+  Start the connection pool.
+
+  `config` is merged with `c:config/0`.
+
+  See `start_link/2` for more details.
+  """
+  @callback start_link(config :: Keyword.t) :: GenServer.on_start()
+
+  @doc """
+  Default configuration for all connection pools.
+
+  ```
+  iex(1)> ConnectionPool.defaults()
+  #{inspect @defaults, pretty: true, width: 0}
+  ```
+  """
+  @spec defaults :: Keyword.t
   def defaults, do: @defaults
 
+  @doc """
+  Merged configuration.
+
+  Takes any configuration found via `Config` and merges it with `defaults/0`.
+  ```
+  iex(1)> ConnectionPool.config()
+  #{inspect @defaults, pretty: true, width: 0}
+
+  config :connection_pool, ConnectionPool, size: 2
+
+  iex(2)> ConnectionPool.config()
+  #{inspect Keyword.put(@defaults, :size, 2), pretty: true, width: 0}
+  ```
+  """
+  @spec config :: Keyword.t
   def config do
     config = Application.get_application(__MODULE__)
     |> Application.get_env(__MODULE__, [])
@@ -20,54 +275,114 @@ defmodule ConnectionPool do
     GenServer.call(pool, :debug)
   end
 
-  def checkout(pool, opts \\ [], f \\ nil)
+  @doc """
+  Checkout a connection from the pool.
 
-  def checkout(pool, opts, nil) when is_list(opts) do
-    GenServer.call(pool, {:checkout, opts}, :infinity)
+  A `:timeout` option can be given (in milliseconds or `:infinity`) that
+  specifies how long to wait if no connection is available in the pool.
+
+  If no `:timeout` option is specified, the one from `config/0` is used.
+
+  Processes that are waiting on connections are replied to in first come, first
+  serve order.
+  """
+  @spec checkout(pool, Keyword.t) :: {:ok, conn} | {:error | :timeout} | {:error, term}
+  def checkout(pool, opts \\ []) do
+    {usec, result} = :timer.tc(fn ->
+      GenServer.call(pool, {:checkout, opts}, :infinity)
+    end)
+
+    :telemetry.execute(
+      [:connection_pool, :checkout],
+      %{usec: usec},
+      %{result: result}
+    )
+
+    result
   end
 
-  def checkout(pool, f, opts) when is_function(f) and (is_nil(opts) or is_list(opts)) do
-    transaction(pool, f, opts || [])
-  end
-
-  def checkout(pool, opts, f) when is_function(f) and is_list(opts) do
-    transaction(pool, f, opts)
-  end
-
-  defp transaction(pool, f, opts) do
-    with {:ok, conn} <- checkout(pool, opts, nil) do
+  def transaction(pool, opts \\ [], f) do
+    with {:ok, conn} <- checkout(pool, opts) do
       try do
-        f.(conn)
+        {:ok, f.(conn)}
       after
         checkin(pool, conn)
       end
     end
   end
 
-  def checkin(pool, name) do
-    GenServer.call(pool, {:checkin, name})
+  def checkin(pool, conn) do
+    {usec, result} = :timer.tc(fn ->
+      GenServer.call(pool, {:checkin, conn})
+    end)
+
+    :telemetry.execute(
+      [:connection_pool, :checkin],
+      %{usec: usec},
+      %{result: result}
+    )
+
+    result
   end
 
-  def start_link(module, config \\ [], opts \\ [])
-
-  def start_link({module, arg}, config, opts) when is_atom(module) do
-    if function_exported?(module, :child_spec, 1) do
-      Keyword.put(config, :start, module.child_spec(arg).start)
-      |> start_link(opts)
-    else
-      {:error, "#{inspect module} must define child_spec/1"}
-    end
+  @doc """
+  Returns a specification to start this module under a supervisor.
+  """
+  @spec child_spec({config :: Keyword.t, gen_opts :: Keyword.t}) :: Supervisor.child_spec()
+  def child_spec({config, gen_opts}) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [config, gen_opts]}
+    }
   end
 
-  def start_link(module, config, opts) when is_atom(module) do
-    start_link({module, []}, config, opts)
+  @spec child_spec(config :: Keyword.t) :: Supervisor.child_spec()
+  def child_spec(config) do
+    super(config)
   end
 
-  def start_link(config, opts, []) when is_list(config) and is_list(opts) do
+
+  @doc """
+  Start a connection pool.
+
+  The given `config` is merged with `config/0`.
+
+  `gen_opts` are passed to the underlying `GenServer.start_link/3` as the last
+  argument.
+
+  ## Options for `config`
+
+  `:start` defines how the pool will create a connection (GenServer). It's a
+  function that takes a name as an argument. The connection must be named using
+  that name.
+  ```
+  fn name -> {SomeConnection, :start_link, [[name: name]]} end
+  ```
+
+  `:size` is an integer specifying the maximum number of connections the pool
+  will have.
+
+  `:timeout` an integer (or `:infinity`) specifying how long `checkout/2` will
+  wait for an available connection.
+
+  ## Examples
+  ```
+  start = fn name ->
+    {Faktory.Client, :start_link, [[host: "foo.bar"], [name: name]]}
+  end
+
+  {:ok, pool} = ConnectionPool.start_link(start: start)
+  {:ok, pool} = ConnectionPool.start_link(start: start, timeout: 1_000)
+  {:ok, pool} = ConnectionPool.start_link(start: start, timeout: 2_000, size: 5)
+  ```
+  """
+  @spec start_link(Keyword.t, Keyword.t) :: {:ok, pid} | {:error, term}
+  def start_link(config \\ [], gen_opts \\ []) when is_list(config) and is_list(gen_opts) do
     config = Keyword.merge(config(), config)
-    GenServer.start_link(__MODULE__, config, opts)
+    GenServer.start_link(__MODULE__, config, gen_opts)
   end
 
+  @doc false
   def init(config) do
     config = Map.new(config)
 
@@ -83,6 +398,7 @@ defmodule ConnectionPool do
       module: module,
       checked_in: names,
       checked_out: %{},
+      checkout_time: %{},
       started: MapSet.new(),
       waiting: :ordsets.new(),
     }
@@ -136,11 +452,16 @@ defmodule ConnectionPool do
     {:noreply, %{state | waiting: waiting}}
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    %{checked_out: checked_out} = state
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    %{checked_out: checked_out, checkout_time: checkout_time} = state
 
-    # Seems better to go through our own internal API rather than try to optimize.
     state = Enum.reduce(checked_out[pid] || [], state, fn name, state ->
+      :telemetry.execute(
+        [:connection_pool, :checkout, :reaped],
+        %{usec: monotonic_time() - checkout_time[name]},
+        %{conn: name, reason: reason}
+      )
+
       check_in(name, pid, state)
     end)
 
@@ -149,17 +470,24 @@ defmodule ConnectionPool do
 
   # No error checking; must be done upstream.
   defp check_out(pid, state) do
-    %{checked_in: checked_in, checked_out: checked_out} = state
+    %{checked_in: checked_in, checked_out: checked_out, checkout_time: checkout_time} = state
 
     [name | checked_in] = checked_in
     checked_out = Map.update(checked_out, pid, MapSet.new([name]), &MapSet.put(&1, name))
+    checkout_time = Map.put(checkout_time, name, monotonic_time())
 
-    {name, %{state | checked_in: checked_in, checked_out: checked_out}}
+    {name, %{state | checked_in: checked_in, checked_out: checked_out, checkout_time: checkout_time}}
   end
 
-  # No error checking; must be upstream.
+  # No error checking; must be done upstream.
   defp check_in(name, pid, state) do
-    %{checked_in: checked_in, checked_out: checked_out} = state
+    %{checked_in: checked_in, checked_out: checked_out, checkout_time: checkout_time} = state
+
+    :telemetry.execute(
+      [:connection_pool, :checkout, :duration],
+      %{usec: monotonic_time() - checkout_time[name]},
+      %{conn: name}
+    )
 
     checked_in = [name | checked_in]
     checked_out = if MapSet.size(checked_out[pid]) == 1 do
@@ -167,8 +495,9 @@ defmodule ConnectionPool do
     else
       Map.update!(checked_out, pid, &MapSet.delete(&1, name))
     end
+    checkout_time = Map.delete(checkout_time, name)
 
-    %{state | checked_in: checked_in, checked_out: checked_out}
+    %{state | checked_in: checked_in, checked_out: checked_out, checkout_time: checkout_time}
   end
 
   defp ensure_started(name, state) do
@@ -212,23 +541,21 @@ defmodule ConnectionPool do
 
   # The waiter specified timeout: :inifinity, thus they have no timer.
   defp reply_to_waiter(name, [{_time, from, nil} | waiting], state) do
-    {pid, _ref} = from
-    {^name, state} = check_out(pid, state)
-    :ok = GenServer.reply(from, {:ok, name})
-    %{state | waiting: waiting}
+    do_reply(name, from, waiting, state)
   end
 
   # Waiter has a timer, but it might have expired already.
   defp reply_to_waiter(name, [{_time, from, timer} | waiting], state) do
     case Process.cancel_timer(timer) do
-      n when is_integer(n) ->
-        {pid, _ref} = from
-        {^name, state} = check_out(pid, state)
-        :ok = GenServer.reply(from, {:ok, name})
-        %{state | waiting: waiting}
-
+      n when is_integer(n) -> do_reply(name, from, waiting, state)
       false -> reply_to_waiter(name, waiting, state)
     end
+  end
+
+  defp do_reply(name, {pid, _ref} = from, waiting, state) do
+    {^name, state} = check_out(pid, state)
+    :ok = GenServer.reply(from, {:ok, name})
+    %{state | waiting: waiting}
   end
 
   defp monotonic_time do

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -1,0 +1,226 @@
+defmodule ConnectionPool do
+  use GenServer
+
+  @defaults [
+    size: 10,
+    timeout: :infinity,
+  ]
+
+  def defaults, do: @defaults
+
+  def config do
+    config = Application.get_application(__MODULE__)
+    |> Application.get_env(__MODULE__, [])
+
+    Keyword.merge(@defaults, config)
+  end
+
+  @doc false
+  def debug(pool) do
+    GenServer.call(pool, :debug)
+  end
+
+  def checkout(pool, opts \\ [], f \\ nil)
+
+  def checkout(pool, opts, nil) when is_list(opts) do
+    GenServer.call(pool, {:checkout, opts}, :infinity)
+  end
+
+  def checkout(pool, f, opts) when is_function(f) and (is_nil(opts) or is_list(opts)) do
+    transaction(pool, f, opts || [])
+  end
+
+  def checkout(pool, opts, f) when is_function(f) and is_list(opts) do
+    transaction(pool, f, opts)
+  end
+
+  defp transaction(pool, f, opts) do
+    with {:ok, conn} <- checkout(pool, opts, nil) do
+      try do
+        f.(conn)
+      after
+        checkin(pool, conn)
+      end
+    end
+  end
+
+  def checkin(pool, name) do
+    GenServer.call(pool, {:checkin, name})
+  end
+
+  def start_link(module, config \\ [], opts \\ [])
+
+  def start_link({module, arg}, config, opts) when is_atom(module) do
+    if function_exported?(module, :child_spec, 1) do
+      Keyword.put(config, :start, module.child_spec(arg).start)
+      |> start_link(opts)
+    else
+      {:error, "#{inspect module} must define child_spec/1"}
+    end
+  end
+
+  def start_link(module, config, opts) when is_atom(module) do
+    start_link({module, []}, config, opts)
+  end
+
+  def start_link(config, opts, []) when is_list(config) and is_list(opts) do
+    config = Keyword.merge(config(), config)
+    GenServer.start_link(__MODULE__, config, opts)
+  end
+
+  def init(config) do
+    config = Map.new(config)
+
+    {module, _, _} = config.start.(nil)
+
+    names = Enum.map(1..config.size, fn _ ->
+      id = :crypto.strong_rand_bytes(7) |> Base.encode16(case: :lower)
+      {:global, {module, id}}
+    end)
+
+    state = %{
+      config: config,
+      module: module,
+      checked_in: names,
+      checked_out: %{},
+      started: MapSet.new(),
+      waiting: :queue.new(),
+    }
+
+    {:ok, state}
+  end
+
+  def handle_call(:debug, _from, state) do
+    {:reply, state, state}
+  end
+
+  def handle_call({:checkout, opts}, {pid, _ref} = from, state) do
+    %{checked_in: checked_in, checked_out: checked_out} = state
+
+    if not Map.has_key?(checked_out, pid) do
+      Process.monitor(pid)
+    end
+
+    if checked_in == [] do
+      {:noreply, add_waiter(from, opts, state)}
+    else
+      {name, state} = check_out(pid, state)
+      case ensure_started(name, state) do
+        {:ok, state} -> {:reply, {:ok, name}, state}
+        error -> {:reply, error, check_in(name, pid, state)}
+      end
+    end
+  end
+
+  def handle_call({:checkin, name}, {pid, _ref}, state) do
+    %{checked_out: checked_out} = state
+
+    if name in (checked_out[pid] || []) do
+      state = check_in(name, pid, state)
+      {:reply, :ok, reply_to_waiter(name, state)}
+    else
+      {:reply, {:error, "not checked out"}, state}
+    end
+  end
+
+  def handle_info({:checkout_timeout, from}, state) do
+    :ok = GenServer.reply(from, {:error, :timeout})
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    %{checked_out: checked_out} = state
+
+    # Seems better to go through our own internal API rather than try to optimize.
+    state = Enum.reduce(checked_out[pid] || [], state, fn name, state ->
+      check_in(name, pid, state)
+    end)
+
+    {:noreply, state}
+  end
+
+  # No error checking; must be done upstream.
+  defp check_out(pid, state) do
+    %{checked_in: checked_in, checked_out: checked_out} = state
+
+    [name | checked_in] = checked_in
+    checked_out = Map.update(checked_out, pid, MapSet.new([name]), &MapSet.put(&1, name))
+
+    {name, %{state | checked_in: checked_in, checked_out: checked_out}}
+  end
+
+  # No error checking; must be upstream.
+  defp check_in(name, pid, state) do
+    %{checked_in: checked_in, checked_out: checked_out} = state
+
+    checked_in = [name | checked_in]
+    checked_out = if MapSet.size(checked_out[pid]) == 1 do
+      Map.delete(checked_out, pid)
+    else
+      Map.update!(checked_out, pid, &MapSet.delete(&1, name))
+    end
+
+    %{state | checked_in: checked_in, checked_out: checked_out}
+  end
+
+  defp ensure_started(name, state) do
+    %{started: started, module: module, config: config} = state
+
+    if name in started do
+      {:ok, state}
+    else
+      DynamicSupervisor.start_child(__MODULE__, %{
+        id: {__MODULE__, module}, # I don't think ids need to be unique with DynamicSupervisor.
+        start: config.start.(name)
+      })
+      |> case do
+        {:ok, _pid} -> {:ok, %{state | started: MapSet.put(started, name)}}
+        error -> error
+      end
+    end
+  end
+
+  defp add_waiter(from, opts, state) do
+    %{config: config, waiting: waiting} = state
+
+    timer = case opts[:timeout] || config.timeout do
+      :infinity -> nil
+      n -> Process.send_after(self(), {:checkout_timeout, from}, n)
+    end
+
+    waiting = :queue.in({from, timer}, waiting)
+
+    %{state | waiting: waiting}
+  end
+
+  defp reply_to_waiter(name, state) do
+    reply_to_waiter(name, :queue.out(state.waiting), state)
+  end
+
+  # No waiters, or all our waiters already timed out.
+  defp reply_to_waiter(_name, {:empty, waiting}, state) do
+    %{state | waiting: waiting}
+  end
+
+  # The waiter specified timeout: :inifinity, thus they have no timer.
+  defp reply_to_waiter(name, {{:value, {from, nil}}, waiting}, state) do
+    {pid, _ref} = from
+    {^name, state} = check_out(pid, state)
+    :ok = GenServer.reply(from, {:ok, name})
+    %{state | waiting: waiting}
+  end
+
+  # Waiter has a timer, but it might have expired already.
+  defp reply_to_waiter(name, {{:value, {from, timer}}, waiting}, state) do
+    case Process.cancel_timer(timer) do
+      n when is_integer(n) ->
+        {pid, _ref} = from
+        {^name, state} = check_out(pid, state)
+        :ok = GenServer.reply(from, {:ok, name})
+        %{state | waiting: waiting}
+
+      false -> reply_to_waiter(name, :queue.out(waiting), state)
+    end
+  end
+
+end

--- a/lib/faktory.ex
+++ b/lib/faktory.ex
@@ -13,13 +13,23 @@ defmodule Faktory do
     %{binary => json}
   )
 
-  # A Faktory job.
   @type job :: %{
-    required(binary) => json
+    required(:jid) => binary,
+    required(:jobtype) => binary,
+    required(:args) => [term],
+    required(:queue) => binary,
+    optional(:reserve_for) => non_neg_integer(),
+    optional(:at) => binary,
+    optional(:retry) => non_neg_integer(),
+    optional(:backtrace) => non_neg_integer(),
+    optional(:created_at) => binary,
+    optional(:enqueued_at) => binary,
+    optional(:failure) => map,
+    optional(:custom) => map
   }
 
   # A connection to the Faktory server.
-  @type conn :: pid
+  @type conn :: GenServer.server()
 
   def get_env(key, default \\ nil) do
     Application.get_env(:faktory_worker_ex, key, default)

--- a/lib/faktory/application.ex
+++ b/lib/faktory/application.ex
@@ -5,7 +5,9 @@ defmodule Faktory.Application do
   def start(_type, _args) do
     :ok = Faktory.Logger.init()
 
-    children = [Faktory.Registry]
+    children = [
+      {DynamicSupervisor, strategy: :one_for_one, name: ConnectionPool}
+    ]
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 end

--- a/lib/faktory/application.ex
+++ b/lib/faktory/application.ex
@@ -3,6 +3,8 @@ defmodule Faktory.Application do
   use Application
 
   def start(_type, _args) do
+    :ok = Faktory.Logger.init()
+
     children = [Faktory.Registry]
     Supervisor.start_link(children, strategy: :one_for_one)
   end

--- a/lib/faktory/client.ex
+++ b/lib/faktory/client.ex
@@ -6,26 +6,51 @@ defmodule Faktory.Client do
   @not_connected "not_connected"
 
   def info(client) do
-    Connection.call(client, :info)
+    case Connection.call(client, :info) do
+      {:ok, info} -> {:ok, Jason.decode!(info)}
+      error -> error
+    end
   end
 
-  def push(client, job, opts \\ [])
-
-  def push(client, job, opts) when is_list(job) do
-    push(client, Map.new(job), opts)
+  def push(client, job, _opts \\ []) do
+    job = Faktory.Job.new(job)
+    case Connection.call(client, {:push, job}) do
+      :ok -> {:ok, job}
+      error -> error
+    end
   end
 
-  def push(_client, _jobs, opts) when not is_list(opts) do
-    raise ArgumentError, "expecting keyword list, got #{inspect opts}"
+  def fetch(client, queues, opts \\ [])
+
+  def fetch(client, queues, opts) when is_list(queues) do
+    fetch(client, Enum.join(queues, " "), opts)
   end
 
-  def push(client, job, _opts) do\
-    job = Map.new(job, fn
-      {k, v} when is_binary(k) -> {String.to_atom(k), v}
-      {k, v} when is_atom(k) -> {k, v}
-      {k, _v} -> raise ArgumentError, "expecting strings or atoms for job keys, got: #{inspect k}"
-    end)
-    Connection.call(client, {:push, job})
+  def fetch(client, queues, _opts) when is_binary(queues) do
+    case Connection.call(client, {:fetch, queues}) do
+      {:ok, job} when is_binary(job) -> {:ok, Faktory.Job.new(job)}
+      result -> result
+    end
+  end
+
+  def ack(client, jid) when is_binary(jid) do
+    Connection.call(client, {:ack, jid})
+  end
+
+  def fail(client, jid, errtype, message, backtrace \\ []) do
+    Connection.call(client, {:fail, jid, errtype, message, backtrace})
+  end
+
+  def flush(client) do
+    Connection.call(client, :flush)
+  end
+
+  def beat(client) do
+    case Connection.call(client, :beat) do
+      {:ok, "OK"} -> :ok
+      {:ok, json} -> {:ok, Jason.decode!(json)}
+      error -> error
+    end
   end
 
   @defaults [
@@ -64,7 +89,7 @@ defmodule Faktory.Client do
       greeting: nil,
       connecting_at: System.monotonic_time(:microsecond),
       disconnected: false,
-      requests: [],
+      calls: :queue.new(),
     }
 
     establish_connection(state)
@@ -85,19 +110,64 @@ defmodule Faktory.Client do
       %{config: state.config, reason: reason}
     )
 
-    # Any pending requests need to fail.
-    Enum.each(state.requests, &GenServer.reply(&1, {:error, @not_connected}))
-
     # Update our state.
     state = %{state |
       socket: nil,
       connecting_at: System.monotonic_time(:microsecond),
-      disconnected: true,
-      requests: []
+      disconnected: true
     }
 
     # Try to reconnect immediately.
     {:connect, :backoff, state}
+  end
+
+  def handle_info({:tcp, socket, line}, state) when state.socket == socket do
+    {{from, at, call}, state} = pop_call(state)
+
+    :telemetry.execute(
+      [:faktory, :socket, :recv],
+      %{usec: System.monotonic_time(:microsecond) - at},
+      %{result: {:ok, line}}
+    )
+
+    result = case Resp.parse(line, socket) do
+      {:ok, {:error, reason}} -> {:error, reason} # Translate RESP -ERR errors.
+      any -> any
+    end
+
+    import Connection, only: [reply: 2]
+
+    case result do
+      {:error, reason} -> reply(from, {:error, reason})
+
+      {:ok, result} -> case call do
+
+        :info -> reply(from, {:ok, result})
+
+        :push -> reply(from, :ok)
+
+        :fetch -> reply(from, {:ok, result})
+
+        :ack -> reply(from, :ok)
+
+        :fail -> reply(from, :ok)
+
+        :flush -> reply(from, :ok)
+
+        :beat -> reply(from, {:ok, result})
+
+      end
+    end
+
+    :telemetry.execute(
+      [:faktory, :client, :call, call],
+      %{usec: System.monotonic_time(:microsecond) - at},
+      %{result: result}
+    )
+
+    :ok = Socket.active(socket, :once)
+
+    {:noreply, state}
   end
 
   def handle_info({:tcp_closed, socket}, state) when state.socket == socket do
@@ -108,27 +178,63 @@ defmodule Faktory.Client do
     {:reply, {:error, @not_connected}, state}
   end
 
-  def handle_call(:info, _from, state) do
-    %{socket: socket} = state
-
-    with :ok <- Socket.active(socket, false),
-      :ok <- Socket.send(socket, Protocol.info()),
-      {:ok, payload} <- Resp.recv(socket),
-      :ok <- Socket.active(socket, :once)
-    do
-      {:reply, {:ok, Jason.decode!(payload)}, state}
-    end
+  def handle_call(:info, from, state) do
+    Socket.send(state.socket, Protocol.info())
+    {:noreply, push_call(from, :info, state)}
   end
 
-  def handle_call({:push, job}, _from, state) do
-    %{socket: socket} = state
+  def handle_call({:push, job}, from, state) do
+    Socket.send(state.socket, Protocol.push(job))
+    {:noreply, push_call(from, :push, state)}
+  end
 
-    with :ok <- Socket.active(socket, false),
-      :ok <- Socket.send(socket, Protocol.push(job)),
-      {:ok, "OK"} <- Resp.recv(socket)
-    do
-      {:reply, {:ok, job}, state}
-    end
+  def handle_call({:fetch, queues}, from, state) do
+    Socket.send(state.socket, Protocol.fetch(queues))
+    {:noreply, push_call(from, :fetch, state)}
+  end
+
+  def handle_call({:ack, jid}, from, state) do
+    Socket.send(state.socket, Protocol.ack(jid))
+    {:noreply, push_call(from, :ack, state)}
+  end
+
+  def handle_call({:fail, jid, errtype, message, backtrace}, from, state) do
+    Socket.send(state.socket, Protocol.fail(jid, errtype, message, backtrace))
+    {:noreply, push_call(from, :fail, state)}
+  end
+
+  def handle_call(:beat, from, state) do
+    Socket.send(state.socket, Protocol.beat(state.config.wid))
+    {:noreply, push_call(from, :beat, state)}
+  end
+
+  def handle_call(:flush, from, state) do
+    Socket.send(state.socket, Protocol.flush())
+    {:noreply, push_call(from, :flush, state)}
+  end
+
+  defp push_call(from, name, state) do
+    %{calls: calls} = state
+
+    item = {
+      from,
+      System.monotonic_time(:microsecond),
+      name
+    }
+
+    calls = :queue.in(item, calls)
+
+    %{state | calls: calls}
+  end
+
+  defp pop_call(state) do
+    %{calls: calls} = state
+
+    {{:value, call}, calls} = :queue.out(calls)
+
+    state = %{state | calls: calls}
+
+    {call, state}
   end
 
   defp establish_connection(state) do

--- a/lib/faktory/job.ex
+++ b/lib/faktory/job.ex
@@ -2,7 +2,7 @@ defmodule Faktory.Job do
   @moduledoc """
   Use this module to create your job processors.
 
-  ### Getting started
+  ## Getting started
 
   All that is required is to define a `perform` function that takes zero or more
   arguments.
@@ -17,148 +17,204 @@ defmodule Faktory.Job do
   end
 
   # To enqueue jobs of this type.
-  MyFunkyJob.perform_async([1, "foo"])
+  {:ok, client} = Faktory.Client.start_link()
+  MyFunkyJob.perform_async([1, "foo"], client: client)
   ```
 
-  **IMPORTANT**: `perform_async` takes a list who's size must match exactly the airty of
-  `perform`.
+  **IMPORTANT**
+  > The first argument to `c:perform_async/2` must be a list of
+  > size exactly equal to the arity of your `perform` function.
 
-  ### Configuring
+  ## Client
 
-  You can configure various aspects of the job by passing a keyword list to
-  `use Faktory.Job` or `faktory_options/1`. They are both functionally the
-  same and it's mostly an issue of style.
+  In order to enqueue a job via `c:perform_async/2`, we need a client connection
+  to the Faktory server.
 
-  ```elixir
+  Consider starting a named `Faktory.Client` (preferably in a supervision tree).
+  ```
+  {:ok, conn} = Faktory.Client.start_link([host: "foo.bar.com"], name: MyFaktoryClient)
+  ```
+
+  Now tell your job to use that client connection.
+  ```
   defmodule MyFunkyJob do
-    use Faktory.Job, queue: "default", retry: 25, backtrace: 0
+    use Faktory.Job, client: MyFaktoryClient
+
+    def perform(n1, n2), do: nil
   end
 
-  # These are equivalent.
+  MyFunkJob.perform_async([1, 2])
+  ```
+
+  See the configuration section below for how to set a global default client.
+
+  ## Configuration
+
+  You can set global configuration that affects all modules via `Config`.
+  ```
+  config :faktory_worker_ex, Faktory.Job,
+    queue: "not-default",
+    client: MyFaktoryClient
 
   defmodule MyFunkyJob do
     use Faktory.Job
-    faktory_options queue: "default", retry: 25, backtrace: 0
+  end
+
+  "not-default" = MyFunkyJob.config[:queue]
+  MyFaktoryClient = MyFunkyJob.config[:client]
+  ```
+
+  You can set job specific configuration at compile time.
+  ```
+  defmodule MyFunkyJob do
+    use Faktory.Job, queue: "funky-queue", client: MyFaktoryClient
   end
   ```
 
-  See `c:faktory_options/0` for available options and defaults.
-
-  ### Runtime overrides
-
-  You can override `faktory_options` when enqueuing a job.
-
-  ```elixir
-  MyFunkyJob.perform_async([1, "foo"], queue: "not_default")
-  MyFunkyJob.perform_async([2, "bar"], retry: 0)
+  Or via `Config`, which allows for run time config via `config/runtime.exs`.
   ```
+  config :your_application, MyFunkyJob,
+    queue: "funky-queue",
+    client: MyFaktoryClient
+  ```
+
+  Config via `Config` takes precedence over compile time config, and job
+  specific config take precedence over the global `Faktory.Job` config. Finally,
+  function call arguments take precedence over config. All config and function
+  arguments are merged together.
   """
 
   @defaults [
     queue: "default",
-    retry: 25,
-    backtrace: 0,
     middleware: [],
-    reserve_for: 1800
   ]
 
   @doc """
-  Returns the default job configuration.
+  Default job configuration.
 
   ```elixir
-  iex(1)> Faktory.Job.defaults
-  #{inspect @defaults}
+  iex(1)> Faktory.Job.defaults()
+  #{inspect @defaults, pretty: true, width: 0}
   ```
   """
   def defaults do
     @defaults
   end
 
-  defmacro __using__(options) do
-    quote do
-      @behaviour Faktory.Job
-      import Faktory.Job, only: [faktory_options: 1]
-      @faktory_options Keyword.merge(Faktory.Job.defaults, jobtype: inspect(__MODULE__))
-      @before_compile Faktory.Job
-
-      faktory_options(unquote(options))
-
-      def perform_async(args, options \\ []) do
-        Faktory.Job.perform_async(@faktory_options, args, options)
-      end
-
-    end
-  end
-
-  defmacro __before_compile__(_env) do
-    quote do
-      def faktory_options do
-        @faktory_options
-      end
-    end
-  end
-
-  @type job :: map
-
   @doc """
-  Returns the default options for a given job module.
+  Global job configuration.
 
+  This overrides the `defaults/1` with configuration specified via `Config`.
   ```
-  iex(5)> MyFunkyJob.faktory_options
-  [
-    queue: "default",
-    jobtype: "MyFunkyJob",
-    retry: 25,
-    middleware: [],
-    backtrace: 10,
-    client: nil
-  ]
+  config :faktory_worker_ex, Faktory.Job, queue: "not-default"
+
+  iex(1)> Faktory.Job.defaults()
+  #{inspect @defaults, pretty: true, width: 0}
+
+  iex(2)> Faktory.Job.config()
+  #{inspect Keyword.merge(@defaults, queue: "not-default"), pretty: true, width: 0}
   ```
   """
-  @callback faktory_options() :: options :: Keyword.t
+  def config do
+    config = Application.get_application(__MODULE__)
+    |> Application.get_env(__MODULE__, [])
+
+    Keyword.merge(@defaults, config)
+  end
+
+  @doc false
+  def new(fields)
+
+  def new(fields) when is_list(fields) or is_map(fields) do
+    Map.new(fields, fn
+      {k, v} when is_atom(k) -> {k, v}
+      {k, v} when is_binary(k) -> {String.to_atom(k), v}
+    end)
+    |> Map.take([
+      :jid,
+      :jobtype,
+      :args,
+      :queue,
+      :reserve_for,
+      :at,
+      :retry,
+      :backtrace,
+      :created_at,
+      :enqueued_at,
+      :failure,
+      :custom
+    ])
+  end
+
+  def new(fields) when is_binary(fields) do
+    Jason.decode!(fields) |> new()
+  end
+
+  defmacro __using__(config \\ []) do
+    quote location: :keep do
+      @behaviour Faktory.Job
+      @config unquote(config)
+
+      def config do
+        config = Application.get_application(__MODULE__)
+        |> Application.get_env(__MODULE__, [])
+
+        Faktory.Job.config()
+        |> Keyword.merge(@config)
+        |> Keyword.merge(config)
+      end
+
+      def perform_async(args, options \\ []) do
+        options = Keyword.merge(config(), options)
+        Faktory.Job.perform_async(args, options)
+      end
+
+    end
+  end
+
+  @type job :: %{
+    required(:jid) => binary,
+    required(:jobtype) => binary,
+    required(:args) => [term],
+    required(:queue) => binary,
+    optional(:reserve_for) => non_neg_integer(),
+    optional(:at) => binary,
+    optional(:retry) => non_neg_integer(),
+    optional(:backtrace) => non_neg_integer(),
+    optional(:created_at) => binary,
+    optional(:enqueued_at) => binary,
+    optional(:failure) => map,
+    optional(:custom) => map
+  }
+
+  @doc """
+  Specific job configuration.
+
+  Returns the configuration for this specific job taking into consideration
+  global configuration, compile time configuration, and run time configuration.
+  """
+  @callback config() :: Keyword.t
 
   @doc """
   Enqueue a job.
 
-  `options` can override any options specified by `faktory_options/1`.
-
-  For all valid options, see `c:faktory_options/0`.
-
+  `options` can override any configuration in `c:config/0`.
   ```
   job_args = [123, "abc"]
   MyJob.perform_async(job_args)
   MyJob.perform_async(job_args, queue: "not_default" jobtype: "Worker::MyJob")
   ```
   """
-  @callback perform_async(args :: [any], options :: Keyword.t | []) :: {:ok, job} | {:error, reason :: binary}
+  @callback perform_async(args :: [term], options :: Keyword.t) :: {:ok, job} | {:error, reason :: term}
 
-  @doc """
-  Set default options for all jobs of this type.
-
-  For all valid options and their defaults, see `c:faktory_options/0`.
-  """
-  @spec faktory_options(Keyword.t) :: term
-  defmacro faktory_options(options) do
-    quote do
-      options = unquote(options)
-      @faktory_options Keyword.merge(@faktory_options, options)
+  @doc false
+  def perform_async(args, options) do
+    case Keyword.pop(options, :client) do
+      {nil, _options} -> {:error, ":client is required"}
+      {client, options} ->
+        job = Keyword.put(options, :args, args) |> new()
+        client.push(job, options)
     end
-  end
-
-  def perform_async(faktory_options, args, options) do
-    options = Keyword.merge(faktory_options, options)
-    job = %{
-      "jobtype" => options[:jobtype],
-      "args" => args,
-      "queue" => options[:queue],
-      "reserve_for" => options[:reserve_for],
-      "at" => options[:at],
-      "retry" => options[:retry],
-      "backtrace" => options[:backtrace]
-    }
-
-    client = options[:client] || Faktory.default_client() || raise("No default client configured")
-    client.push(job, options)
   end
 
 end

--- a/lib/faktory/job.ex
+++ b/lib/faktory/job.ex
@@ -172,21 +172,6 @@ defmodule Faktory.Job do
     end
   end
 
-  @type job :: %{
-    required(:jid) => binary,
-    required(:jobtype) => binary,
-    required(:args) => [term],
-    required(:queue) => binary,
-    optional(:reserve_for) => non_neg_integer(),
-    optional(:at) => binary,
-    optional(:retry) => non_neg_integer(),
-    optional(:backtrace) => non_neg_integer(),
-    optional(:created_at) => binary,
-    optional(:enqueued_at) => binary,
-    optional(:failure) => map,
-    optional(:custom) => map
-  }
-
   @doc """
   Specific job configuration.
 
@@ -205,7 +190,7 @@ defmodule Faktory.Job do
   MyJob.perform_async(job_args, queue: "not_default" jobtype: "Worker::MyJob")
   ```
   """
-  @callback perform_async(args :: [term], options :: Keyword.t) :: {:ok, job} | {:error, reason :: term}
+  @callback perform_async(args :: [term], options :: Keyword.t) :: {:ok, Faktory.job} | {:error, reason :: term}
 
   @doc false
   def perform_async(args, options) do
@@ -213,7 +198,7 @@ defmodule Faktory.Job do
       {nil, _options} -> {:error, ":client is required"}
       {client, options} ->
         job = Keyword.put(options, :args, args) |> new()
-        client.push(job, options)
+        Faktory.Client.push(client, job, options)
     end
   end
 

--- a/lib/faktory/logger.ex
+++ b/lib/faktory/logger.ex
@@ -11,6 +11,13 @@ defmodule Faktory.Logger do
         [:faktory, :client, :connection, :success],
         [:faktory, :client, :connection, :failure],
         [:faktory, :client, :connection, :disconnect],
+        [:faktory, :client, :call, :info],
+        [:faktory, :client, :call, :push],
+        [:faktory, :client, :call, :fetch],
+        [:faktory, :client, :call, :ack],
+        [:faktory, :client, :call, :fail],
+        [:faktory, :client, :call, :flush],
+        [:faktory, :client, :call, :beat],
       ],
       &__MODULE__.log/4,
       nil
@@ -68,6 +75,16 @@ defmodule Faktory.Logger do
     server = "#{meta.config.host}:#{meta.config.port}"
 
     Logger.warn("Disconnected from #{server} (#{meta.reason})")
+  end
+
+  def log([:faktory, :client, :call, call], %{usec: usec}, meta, _config) do
+    time = Faktory.Utils.format_duration(usec)
+    case meta.result do
+      {:error, _reason} ->
+        Logger.warn("#{call} failed in #{time}")
+      _success ->
+        Logger.debug("#{call} executed in #{time}")
+    end
   end
 
   def log(_, _, _, _), do: nil

--- a/lib/faktory/logger.ex
+++ b/lib/faktory/logger.ex
@@ -2,6 +2,21 @@ defmodule Faktory.Logger do
   @moduledoc false
   require Logger
 
+  def init do
+    :telemetry.attach_many(
+      inspect(__MODULE__),
+      [
+        [:faktory, :socket, :recv],
+        [:faktory, :socket, :send],
+        [:faktory, :client, :connection, :success],
+        [:faktory, :client, :connection, :failure],
+        [:faktory, :client, :connection, :disconnect],
+      ],
+      &__MODULE__.log/4,
+      nil
+    )
+  end
+
   def debug(msg), do: log(:debug, "[faktory] #{msg}")
   def info(msg),  do: log(:info,  "[faktory] #{msg}")
   def warn(msg),  do: log(:warn,  "[faktory] #{msg}")
@@ -13,5 +28,48 @@ defmodule Faktory.Logger do
       Logger.log(level, message)
     end
   end
+
+  def log([:faktory, :socket, :recv], time, %{result: {:ok, data}}, _config) do
+    time = Faktory.Utils.format_duration(time.usec)
+
+    Logger.debug("<<- #{inspect data} in #{time}")
+  end
+
+  def log([:faktory, :socket, :send], time, %{result: :ok, data: data}, _config) do
+    data = case data do
+      data when is_list(data) -> IO.iodata_to_binary(data)
+      data -> data
+    end
+
+    time = Faktory.Utils.format_duration(time.usec)
+
+    Logger.debug("->> #{inspect data} in #{time}")
+  end
+
+  def log([:faktory, :client, :connection, :success], %{usec: usec}, meta, _config) do
+    time = Faktory.Utils.format_duration(usec)
+    server = "#{meta.config.host}:#{meta.config.port}"
+
+    if meta.disconnected do
+      Logger.info("Connection reestablished to #{server} in #{time}")
+    else
+      Logger.debug("Connection established to #{server} in #{time}")
+    end
+  end
+
+  def log([:faktory, :client, :connection, :failure], %{usec: usec}, meta, _config) do
+    time = Faktory.Utils.format_duration(usec)
+    server = "#{meta.config.host}:#{meta.config.port}"
+
+    Logger.warn("Connection failed to #{server} (#{meta.reason}), down for #{time}")
+  end
+
+  def log([:faktory, :client, :connection, :disconnect], _time, meta, _config) do
+    server = "#{meta.config.host}:#{meta.config.port}"
+
+    Logger.warn("Disconnected from #{server} (#{meta.reason})")
+  end
+
+  def log(_, _, _, _), do: nil
 
 end

--- a/lib/faktory/protocol.ex
+++ b/lib/faktory/protocol.ex
@@ -41,8 +41,34 @@ defmodule Faktory.Protocol do
   end
 
   def push(job) do
-    payload = Jason.encode!(job)
-    ["PUSH", " ", payload, "\r\n"]
+    ["PUSH", " ", Jason.encode!(job), "\r\n"]
+  end
+
+  def fetch(queues) do
+    ["FETCH", " ", queues, "\r\n"]
+  end
+
+  def ack(jid) do
+    ["ACK", " ", Jason.encode!(%{jid: jid}), "\r\n"]
+  end
+
+  def beat(wid) do
+    ["BEAT", " ", Jason.encode!(%{wid: wid}), "\r\n"]
+  end
+
+  def flush do
+    ["FLUSH", "\r\n"]
+  end
+
+  def fail(jid, errtype, message, backtrace) do
+    payload = %{
+      jid: jid,
+      errtype: errtype,
+      message: message,
+      backtrace: backtrace
+    } |> Jason.encode!
+
+    ["FAIL", " ", payload, "\r\n"]
   end
 
   def handshake(conn, hello) do

--- a/lib/faktory/protocol.ex
+++ b/lib/faktory/protocol.ex
@@ -17,6 +17,34 @@ defmodule Faktory.Protocol do
 
   alias Faktory.{Utils, Connection, Resp}
 
+  def hello(_greeting, _config) do
+    # %{
+    #   password: state.password,
+    #   hostname: Utils.hostname,
+    #   pid: Utils.unix_pid,
+    #   labels: ["elixir"],
+    #   v: 2,
+    # }
+
+    payload = %{
+      hostname: Utils.hostname(),
+      pid: Utils.unix_pid(),
+      labels: ["elixir"],
+      v: 2
+    } |> Jason.encode!()
+
+    ["HELLO", " ", payload, "\r\n"]
+  end
+
+  def info do
+    ["INFO", "\r\n"]
+  end
+
+  def push(job) do
+    payload = Jason.encode!(job)
+    ["PUSH", " ", payload, "\r\n"]
+  end
+
   def handshake(conn, hello) do
     with \
       {:ok, <<"HI", json::binary>>} <- Resp.recv(conn),
@@ -39,18 +67,6 @@ defmodule Faktory.Protocol do
     end
     |> Map.delete(:password)
     |> Jason.encode(hello)
-  end
-
-  @spec push(conn, job) :: success | network_error | server_error
-
-  def push(conn, job) when is_list(job), do: push(conn, Map.new(job))
-
-  def push(conn, job) do
-    payload = Jason.encode!(job)
-
-    with :ok <- Connection.send(conn, "PUSH #{payload}") do
-      Resp.recv(conn)
-    end
   end
 
   def fetch(conn, queues) when is_list(queues) do

--- a/lib/faktory/socket.ex
+++ b/lib/faktory/socket.ex
@@ -1,48 +1,63 @@
-# This is a very thin wrapper over Socket and Socket.Stream in order smooth over
-# some idiosyncrasies and to make mocking easier.
 defmodule Faktory.Socket do
   @moduledoc false
 
-  @type socket :: Socket.t
-  @type size :: :line | integer
-  @type options :: Keyword.t
+  def connect(host, port, opts \\ [])
 
-  @callback connect(uri :: binary) :: {:ok, socket} | {:error, term}
-  @callback close(socket) :: :ok | {:error, term}
-  @callback send(socket, data :: binary) :: :ok | {:error, term}
-  @callback recv(socket, size, options) :: {:ok, binary} | {:error, term}
-
-  defdelegate connect(uri), to: Socket
-  defdelegate close(socket), to: Socket
-  defdelegate send(socket, data), to: Socket.Stream
-
-  @spec recv(Socket.t, size, options) :: {:ok, binary} | {:error | term}
-  def recv(socket, size, options \\ [])
-
-  # Tricky use of "with" here.
-  #
-  # For some reason Socket.Stream.recv will return {:ok, nil} before
-  # returning {:error, reason}. We swallow that {:ok, nil}
-  # so that the caller can get the {:error, reason}.
-  #
-  # The implicit "else" clause of the "with" statement will return either:
-  #   {:ok, data}
-  #   {:error, reason}
-
-  def recv(socket, :line, options) do
-    with :ok <- Socket.packet(socket, :line),
-      {:ok, nil} <- Socket.Stream.recv(socket, options)
-    do
-      recv(socket, :line, options)
-    end
+  def connect(host, port, opts) when is_binary(host) do
+    connect(String.to_charlist(host), port, opts)
   end
 
-  def recv(socket, size, options) do
-    with :ok <- Socket.packet(socket, :raw),
-      {:ok, nil} <- Socket.Stream.recv(socket, size, options)
-    do
-      recv(socket, size, options)
-    end
+  def connect(host, port, opts) do
+    :gen_tcp.connect(host, port, opts)
+  end
+
+  def close(socket) when is_port(socket) do
+    :gen_tcp.close(socket)
+  end
+
+  def active(socket, how) when is_port(socket) and how in [:once, false] do
+    :inet.setopts(socket, active: how)
+  end
+
+  def recv(socket, :line) when is_port(socket) do
+    {usec, result} = :timer.tc(fn -> :gen_tcp.recv(socket, 0) end)
+
+    :telemetry.execute(
+      [:faktory, :socket, :recv],
+      %{usec: usec},
+      %{result: result}
+    )
+
+    result
+  end
+
+  def recv(socket, n) when is_port(socket) and is_integer(n) do
+    {usec, result} = :timer.tc(fn ->
+      :ok = :inet.setopts(socket, packet: :raw)
+      result = :gen_tcp.recv(socket, n)
+      :ok = :inet.setopts(socket, packet: :line)
+      result
+    end)
+
+    :telemetry.execute(
+      [:faktory, :socket, :recv],
+      %{usec: usec},
+      %{result: result}
+    )
+
+    result
+  end
+
+  def send(socket, data) when is_port(socket) do
+    {usec, result} = :timer.tc(fn -> :gen_tcp.send(socket, data) end)
+
+    :telemetry.execute(
+      [:faktory, :socket, :send],
+      %{usec: usec},
+      %{result: result, data: data}
+    )
+
+    result
   end
 
 end

--- a/lib/faktory/utils.ex
+++ b/lib/faktory/utils.ex
@@ -81,4 +81,19 @@ defmodule Faktory.Utils do
     inspect(args, binaries: :as_strings, charlists: :as_lists)
   end
 
+  def format_duration(usec) do
+    cond do
+      usec < 1_000 ->
+        "#{usec}μs"
+
+      usec < 10_000_000 ->
+        ms = usec / 1_000 |> round()
+        "#{ms}ms"
+
+      true ->
+        s = usec / 1_000_000 |> round()
+        "#{s}s"
+    end
+  end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -49,8 +49,8 @@ defmodule Faktory.Mixfile do
       {:connection, "~> 1.0"},
       {:jason, "~> 1.1"},
       {:poolboy, "~> 1.5"},
-      {:socket, "~> 0.3"},
       {:gen_stage, "~> 1.0"},
+      {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.19", only: :dev},
       {:mox, "~> 0.3", only: :test},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -10,4 +10,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm", "dad79704ce5440f3d5a3681c8590b9dc25d1a561e8f5a9c995281012860901e3"},
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
+  "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
 }


### PR DESCRIPTION
Make a basic Faktory client that does nothing more than speak the Faktory protocol, then refactor the entire library to use that one simple thing.

The client should be the basic building block upon which all other complex abstractions are built upon. This will overall simplify the code.